### PR TITLE
Allow tab to close after typing 'exit' at the commandline.

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -575,6 +575,8 @@ namespace PantheonTerminal {
                         /* If a program was running, do not close the tab so that output of program
                          * remains visible */
                         t.active_shell (location);
+                        /* Allow closing tab with "exit" */
+                        program = null;
                     } else {
                         t.tab.close ();
                     }


### PR DESCRIPTION
Nullify 'program' variable after program exits so next "child-exited" signal from terminal closes the tab.

Fixes #91 