### PR TITLE
Replace compact class with default-decoration

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -188,7 +188,7 @@ namespace PantheonTerminal {
 
             var header = new Gtk.HeaderBar ();
             header.set_show_close_button (true);
-            header.get_style_context ().add_class ("compact");
+            header.get_style_context ().add_class ("default-decoration");
 
             this.set_titlebar (header);
 


### PR DESCRIPTION
This replaces an elementary-specific style class with a class used by Gtk itself. There should be no visible difference.

The purpose of this class is to reduce the padding in Terminal's headerbar