### PR TITLE
Disable handling F10 key by Gtk itself

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -113,7 +113,11 @@ namespace PantheonTerminal {
             icon_name = "utilities-terminal";
             set_application (app);
 
-            Gtk.Settings.get_default ().gtk_application_prefer_dark_theme = true;
+            var settings = Gtk.Settings.get_default ();
+            settings.gtk_application_prefer_dark_theme = true;
+
+            /* Make GTK+ CSD not steal F10 from the terminal */
+            settings.gtk_menu_bar_accel = null;
 
             set_visual (Gdk.Screen.get_default ().get_rgba_visual ());
 


### PR DESCRIPTION
This disables Gtk from handling F10 key itself so that other widgets can further receive the event.
The solution itself wasn't found by me, I just searched "F10" in VTE's source code and found this:
https://github.com/GNOME/vte/blob/c9e7cbabfe2fd682a80dd8938c317e7aed1195f4/src/vteapp.c#L897.

We don't use any menus, while e.g: GNOME's Terminal does use menu and pressing F10 does trigger opening the menu there, but prevents from receiving the event by the terminal itself.