### PR TITLE
Move PantheonTerminal.vala to Application.vala

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,9 +70,9 @@ ensure_vala_version ("0.22.0" MINIMUM)
 
 include (ValaPrecompile)
 vala_precompile (VALA_C
+    src/Application.vala
     src/DBus.vala
     src/Settings.vala
-    src/PantheonTerminal.vala
     src/PantheonTerminalWindow.vala
     src/TerminalWidget.vala
     src/ForegroundProcessDialog.vala

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,25 +1,23 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
-/***
-    BEGIN LICENSE
-
-    Copyright (C) 2011-2014 Pantheon Terminal Developers
-    This program is free software: you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License version 3, as published
-    by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranties of
-    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
-    PURPOSE.  See the GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program.  If not, see <http://www.gnu.org/licenses/>
-
-    END LICENSE
- ***/
+/*
+* Copyright (c) 2011-2017 elementary LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 3, as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
 
 namespace PantheonTerminal {
-
     public class PantheonTerminalApp : Granite.Application {
 
         private GLib.List <PantheonTerminalWindow> windows;
@@ -189,7 +187,7 @@ namespace PantheonTerminal {
             return length > 0 ? windows.nth_data (length - 1) : null;
         }
 
-        static const OptionEntry[] entries = {
+        private const OptionEntry[] entries = {
             { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
             { "execute", 'e', 0, OptionArg.STRING_ARRAY, ref command_e, N_("Run a program in terminal"), "" },
             { "working-directory", 'w', 0, OptionArg.FILENAME, ref working_directory, N_("Set shell working directory"), "" },
@@ -201,4 +199,4 @@ namespace PantheonTerminal {
             return app.run (args);
         }
     }
-} // Namespace
+}


### PR DESCRIPTION
* Rename to be in line with naming from other repos and make the app class easy to find
* Update license header
* static is not applicable to constants