### PR TITLE
rewrite SearchToolbar.vala

### DIFF
--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -1,101 +1,91 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
-/***
-    BEGIN LICENSE
-
-    Copyright (C) 2011-2015 Pantheon Terminal Developers
-    This program is free software: you can redistribute it and/or modify it
-    under the terms of the GNU Lesser General Public License version 3, as published
-    by the Free Software Foundation.
-
-    This program is distributed in the hope that it will be useful, but
-    WITHOUT ANY WARRANTY; without even the implied warranties of
-    MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
-    PURPOSE.  See the GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License along
-    with this program.  If not, see <http://www.gnu.org/licenses/>
-
-    END LICENSE
- ***/
+/*
+* Copyright (c) 2011-2017 elementary LLC. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 3 as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
 
 namespace PantheonTerminal.Widgets {
 
     public class SearchToolbar : Gtk.Toolbar {
-        // Parent window
-        private weak PantheonTerminalWindow window;
+        public weak PantheonTerminalWindow window { get; construct; }
+        public Gtk.SearchEntry search_entry;
 
         private Gtk.ToolItem tool_search_entry;
 
-        public Gtk.SearchEntry search_entry;
-
-        public signal void clear ();
-
         public SearchToolbar (PantheonTerminalWindow window) {
-            this.window = window;
+            Object (window: window);
+        }
 
-            this.search_entry = new Gtk.SearchEntry ();
-            this.search_entry.placeholder_text = _("Find");
-            this.search_entry.width_request = 250;
-            this.search_entry.margin_left = 6;
+        construct {
+            search_entry = new Gtk.SearchEntry ();
+            search_entry.placeholder_text = _("Find");
+            search_entry.width_request = 250;
+            search_entry.margin_left = 6;
 
-            // Items
-            this.tool_search_entry = new Gtk.ToolItem ();
-            this.tool_search_entry.add (search_entry);
+            tool_search_entry = new Gtk.ToolItem ();
+            tool_search_entry.add (search_entry);
 
-            var i = new Gtk.Image.from_icon_name ("go-up-symbolic",
-                                                  Gtk.IconSize.SMALL_TOOLBAR);
-            i.pixel_size = 16;
-            var previous_button = new Gtk.ToolButton (i, null);
-            previous_button.set_tooltip_text (_("Previous result"));
+            var previous_image = new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            previous_image.pixel_size = 16;
 
-            i = new Gtk.Image.from_icon_name ("go-down-symbolic",
-                                              Gtk.IconSize.SMALL_TOOLBAR);
-            i.pixel_size = 16;
-            var next_button = new Gtk.ToolButton (i, null);
-            next_button.set_tooltip_text (_("Next result"));
+            var previous_button = new Gtk.ToolButton (previous_image, null);
+            previous_button.tooltip_text = _("Previous result");
 
-            this.add (tool_search_entry);
-            this.add (previous_button);
-            this.add (next_button);
+            var next_image = new Gtk.Image.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            next_image.pixel_size = 16;
 
-            this.show_all ();
-            this.set_style (Gtk.ToolbarStyle.ICONS);
-            this.get_style_context ().add_class ("search-bar");
+            var next_button = new Gtk.ToolButton (next_image, null);
+            next_button.tooltip_text = _("Next result");
 
-            // Signals and callbacks
-            this.clear.connect (clear_cb);
-            this.grab_focus.connect (grab_focus_cb);
-            this.search_entry.search_changed.connect (search_changed_cb);
+            add (tool_search_entry);
+            add (previous_button);
+            add (next_button);
+
+            get_style_context ().add_class ("search-bar");
+            show_all ();
+
+            grab_focus.connect (() => {
+                search_entry.grab_focus ();
+            });
+
+            search_entry.search_changed.connect (() => {
+                try {
+                    // FIXME Have a configuration menu or something.
+                    var regex = new Regex (Regex.escape_string (search_entry.text), RegexCompileFlags.CASELESS);
+                    window.current_terminal.search_set_gregex (regex, 0);
+                    window.current_terminal.search_set_wrap_around (true);
+                } catch (RegexError er) {
+                    warning ("There was an error to compile the regex: %s", er.message);
+                }
+            });
+
             previous_button.clicked.connect (previous_search);
             next_button.clicked.connect (next_search);
         }
 
-        void clear_cb () {
-            this.search_entry.text = "";
-        }
-
-        void grab_focus_cb () {
-            this.search_entry.grab_focus ();
-        }
-
-        void search_changed_cb () {
-            try {
-                // FIXME Have a configuration menu or something.
-                var regex = new Regex (Regex.escape_string (search_entry.text),
-                                       RegexCompileFlags.CASELESS);
-                this.window.current_terminal.search_set_gregex (regex, 0);
-                this.window.current_terminal.search_set_wrap_around (true);
-            } catch (RegexError er) {
-                warning ("There was an error to compile the regex: %s", er.message);
-            }
+        public void clear () {
+            search_entry.text = "";
         }
 
         public void previous_search () {
-            this.window.current_terminal.search_find_previous ();
+            window.current_terminal.search_find_previous ();
         }
 
         public void next_search () {
-            this.window.current_terminal.search_find_next ();
+            window.current_terminal.search_find_next ();
         }
     }
 }

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -23,10 +23,11 @@ namespace PantheonTerminal.Widgets {
         public weak PantheonTerminalWindow window { get; construct; }
         public Gtk.SearchEntry search_entry;
 
-        private Gtk.ToolItem tool_search_entry;
-
         public SearchToolbar (PantheonTerminalWindow window) {
-            Object (window: window);
+            Object (
+                icon_size: Gtk.IconSize.SMALL_TOOLBAR,
+                window: window
+            );
         }
 
         construct {
@@ -35,19 +36,13 @@ namespace PantheonTerminal.Widgets {
             search_entry.width_request = 250;
             search_entry.margin_left = 6;
 
-            tool_search_entry = new Gtk.ToolItem ();
+            var tool_search_entry = new Gtk.ToolItem ();
             tool_search_entry.add (search_entry);
 
-            var previous_image = new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            previous_image.pixel_size = 16;
-
-            var previous_button = new Gtk.ToolButton (previous_image, null);
+            var previous_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR), null);
             previous_button.tooltip_text = _("Previous result");
 
-            var next_image = new Gtk.Image.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
-            next_image.pixel_size = 16;
-
-            var next_button = new Gtk.ToolButton (next_image, null);
+            var next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR), null);
             next_button.tooltip_text = _("Next result");
 
             add (tool_search_entry);


### PR DESCRIPTION
* GObject-style construction
* Update copyright header
* Use lambdas for methods that don't get re-used
* Reduce variable scope
* Don't create variables when unnecessary 
* Don't use `this`
* Make `clear ()` a public method instead of a signal