### PR TITLE
Port accelerators over to GLib.action

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -885,10 +885,6 @@ namespace PantheonTerminal {
                 new_tab (Environment.get_home_dir ());
         }
 
-        void action_about () {
-            app.show_about (this);
-        }
-
         void action_zoom_in_font () {
             current_terminal.increment_size ();
             set_zoom_default_label (current_terminal.zoom_factor);

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -50,27 +50,33 @@ namespace PantheonTerminal {
             }
         """;
 
+        public SimpleActionGroup actions { get; construct; }
+
+        public const string ACTION_PREFIX = "win.";
+        public const string ACTION_CLOSE_TAB = "action_close_tab";
+        public const string ACTION_FULLSCREEN = "action_fullscreen";
+        public const string ACTION_NEW_TAB = "action_new_tab";
+        public const string ACTION_NEW_WINDOW = "action_new_window";
+        public const string ACTION_NEXT_TAB = "action_next_tab";
+        public const string ACTION_PREVIOUS_TAB = "action_previous_tab";
+        public const string ACTION_ZOOM_IN_FONT = "action_zoom_in_font";
+        public const string ACTION_ZOOM_OUT_FONT = "action_zoom_out_font";
+
+        private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
+
+        private const ActionEntry[] action_entries = {
+            { ACTION_CLOSE_TAB, action_close_tab },
+            { ACTION_FULLSCREEN, action_fullscreen },
+            { ACTION_NEW_TAB, action_new_tab },
+            { ACTION_NEW_WINDOW, action_new_window },
+            { ACTION_NEXT_TAB, action_next_tab },
+            { ACTION_PREVIOUS_TAB, action_previous_tab },
+            { ACTION_ZOOM_IN_FONT, action_zoom_in_font },
+            { ACTION_ZOOM_OUT_FONT, action_zoom_out_font }
+        };
+
         const string ui_string = """
             <ui>
-            <popup name="MenuItemTool">
-                <menuitem name="New window" action="New window"/>
-                <menuitem name="New tab" action="New tab"/>
-                <menuitem name="CloseTab" action="CloseTab"/>
-                <menuitem name="Copy" action="Copy"/>
-                <menuitem name="Paste" action="Paste"/>
-                <menuitem name="Select All" action="Select All"/>
-                <menuitem name="Search" action="Search"/>
-                <menuitem name="About" action="About"/>
-
-                <menuitem name="NextTab" action="NextTab"/>
-                <menuitem name="PreviousTab" action="PreviousTab"/>
-
-                <menuitem name="ZoomIn" action="ZoomIn"/>
-                <menuitem name="ZoomOut" action="ZoomOut"/>
-
-                <menuitem name="Fullscreen" action="Fullscreen"/>
-            </popup>
-
             <popup name="AppMenu">
                 <menuitem name="Copy" action="Copy"/>
                 <menuitem name="Paste" action="Paste"/>
@@ -102,6 +108,23 @@ namespace PantheonTerminal {
             new_tab (location);
         }
 
+        static construct {
+            action_accelerators[ACTION_CLOSE_TAB] = "<Control><Shift>w";
+            action_accelerators[ACTION_FULLSCREEN] = "F11";
+            action_accelerators[ACTION_NEW_TAB] = "<Control><Shift>t";
+            action_accelerators[ACTION_NEW_WINDOW] = "<Control><Shift>n";
+            action_accelerators[ACTION_NEXT_TAB] = "<Control><Shift>Right";
+            action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Left";
+            action_accelerators[ACTION_ZOOM_IN_FONT] = "<Control>plus";
+            action_accelerators[ACTION_ZOOM_OUT_FONT] = "<Control>minus";
+        }
+
+        construct {
+            actions = new SimpleActionGroup ();
+            actions.add_action_entries (action_entries, this);
+            insert_action_group ("win", actions);
+        }
+
         public void add_tab_with_command (string command) {
             new_tab ("", command);
         }
@@ -113,6 +136,10 @@ namespace PantheonTerminal {
         private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true) {
             icon_name = "utilities-terminal";
             set_application (app);
+
+            foreach (var action in action_accelerators.get_keys ()) {
+                app.set_accels_for_action (ACTION_PREFIX + action, action_accelerators[action].to_array ());
+            }
 
             var settings = Gtk.Settings.get_default ();
             settings.gtk_application_prefer_dark_theme = true;
@@ -983,60 +1010,11 @@ namespace PantheonTerminal {
         }
 
         static const Gtk.ActionEntry[] main_entries = {
-            { "CloseTab", "gtk-close", N_("Close"),
-              "<Control><Shift>w", N_("Close"),
-              action_close_tab },
-
-            { "New window", "window-new",
-              N_("New Window"), "<Control><Shift>n", N_("Open a new window"),
-              action_new_window },
-
-            { "New tab", "gtk-new",
-              N_("New Tab"), "<Control><Shift>t", N_("Create a new tab"),
-              action_new_tab },
-
-            { "Copy", "gtk-copy",
-              N_("Copy"), "<Control><Shift>c", N_("Copy the selected text"),
-              action_copy },
-
-            { "Search", "edit-find",
-              N_("Find…"), "<Control><Shift>f",
-              N_("Search for a given string in the terminal"), action_search },
-
-            { "Paste", "gtk-paste",
-              N_("Paste"), "<Control><Shift>v", N_("Paste some text"),
-              action_paste },
-
-            { "Select All", "gtk-select-all",
-              N_("Select All"), "<Control><Shift>a",
-              N_("Select all the text in the terminal"), action_select_all },
-
-            { "Show in File Browser", "gtk-directory",
-              N_("Show in File Browser"), "<Control><Shift>e",
-              N_("Open current location in Files"), action_open_in_files },
-
-            { "About", "gtk-about", N_("About"),
-              null, N_("Show about window"), action_about },
-
-            { "NextTab", null, N_("Next Tab"),
-              "<Control><Shift>Right", N_("Go to next tab"),
-              action_next_tab },
-
-            { "PreviousTab", null, N_("Previous Tab"),
-              "<Control><Shift>Left", N_("Go to previous tab"),
-              action_previous_tab },
-
-            { "ZoomIn", "gtk-zoom-in", N_("Zoom in"),
-              "<Control>plus", N_("Zoom in"),
-              action_zoom_in_font },
-
-            { "ZoomOut", "gtk-zoom-out",
-              N_("Zoom out"), "<Control>minus", N_("Zoom out"),
-              action_zoom_out_font },
-
-            { "Fullscreen", "gtk-fullscreen",
-              N_("Fullscreen"), "F11", N_("Toggle/Untoggle fullscreen"),
-              action_fullscreen }
+            { "Copy", null, N_("Copy"), "<Control><Shift>c", null, action_copy },
+            { "Search", null, N_("Find…"), "<Control><Shift>f", null, action_search },
+            { "Paste", null, N_("Paste"), "<Control><Shift>v", null, action_paste },
+            { "Select All", null, N_("Select All"), "<Control><Shift>a", null, action_select_all },
+            { "Show in File Browser", null, N_("Show in File Browser"), "<Control><Shift>e", null, action_open_in_files }
         };
     }
 }


### PR DESCRIPTION
Port only accelerators over to GLib.Action. Don't port anything in the context menu.

This is a portion of the work from #146 that doesn't appear to cause any regression