### PR TITLE
Tab label and window title fallback to "Terminal" rather than blank.

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -27,6 +27,7 @@ namespace PantheonTerminal {
             TEXT
         }
 
+        internal const string DEFAULT_LABEL = _("Terminal");
         public PantheonTerminalApp app;
         public string terminal_id;
         static int terminal_id_counter = 0;
@@ -52,15 +53,17 @@ namespace PantheonTerminal {
         public Granite.Widgets.Tab tab;
         public string? uri;
 
-        private string _tab_label = "";
+        private string _tab_label;
         public string tab_label {
             get {
                 return _tab_label;
             }
 
             set {
-                _tab_label = value;
-                tab.label = tab_label;
+                if (value != null) {
+                    _tab_label = value;
+                    tab.label = tab_label;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #154.

This issue is caused by a signal that Terminal relies on not being emitted from Vte.Terminal when the .bashrc does not force setting of the window title. There appears to be no simple way to fix this in Terminal so this branch simply avoids having any blank tabs or titles under these circumstances (all labelled "Terminal").