### PR TITLE
Dark light settings

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -83,6 +83,11 @@
       <summary>Defined whether to use ctrl-c or ctrl-shift-c for copy</summary>
       <description>Enables or disables natural copy paste.</description>
     </key>
+    <key name="prefer-dark-style" type="b">
+      <default>true</default>
+      <summary>Defined whether to use dark stylesheet from Gtk</summary>
+      <description>Switches between dark and light style</description>
+    </key>
 
     <key name="foreground" type="s">
       <default>"#94a3a5"</default>

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -248,6 +248,12 @@ namespace PantheonTerminal {
             color_button.append_text (_("Light"));
             color_button.append_text (_("Dark"));
 
+            if (settings.prefer_dark_style) {
+                color_button.selected = 1;
+            } else {
+                color_button.selected = 0;
+            }
+
             var style_popover_grid = new Gtk.Grid ();
             style_popover_grid.margin = 12;
             style_popover_grid.orientation = Gtk.Orientation.VERTICAL;

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -885,10 +885,6 @@ namespace PantheonTerminal {
                 new_tab (Environment.get_home_dir ());
         }
 
-        void action_about () {
-            app.show_about (this);
-        }
-
         void action_zoom_in_font () {
             current_terminal.increment_size ();
             set_zoom_default_label (current_terminal.zoom_factor);

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -53,6 +53,31 @@ namespace PantheonTerminal {
             .terminal-window.background.maximized {
                 background-color: #000;
             }
+
+            .color-button {
+                border-radius: 50%;
+                box-shadow:
+                    inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
+                    inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
+                    0 1px 0 0 alpha (@bg_highlight_color, 0.3);
+            }
+
+            .color-button:focus {
+                border-color: @colorAccent;
+            }
+
+            .color-dark {
+                background-color: #252E32;
+                border-color: #151B1C;
+            }
+
+            .color-light {
+                background-color: #fdf6e3;
+            }
+
+            .color-white {
+                background-color: #fff;
+            }
         """;
 
         public SimpleActionGroup actions { get; construct; }
@@ -244,23 +269,45 @@ namespace PantheonTerminal {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
-            var color_button = new Granite.Widgets.ModeButton ();
-            color_button.append_text (_("Light"));
-            color_button.append_text (_("Dark"));
+            var color_button_light = new Gtk.Button ();
+            color_button_light.halign = Gtk.Align.CENTER;
+            color_button_light.height_request = 32;
+            color_button_light.width_request = 32;
+            color_button_light.tooltip_text = _("Solarized Light");
 
-            if (settings.prefer_dark_style) {
-                color_button.selected = 1;
-            } else {
-                color_button.selected = 0;
-            }
+            var color_button_light_context = color_button_light.get_style_context ();
+            color_button_light_context.add_class ("color-button");
+            color_button_light_context.add_class ("color-light");
+
+            var color_button_dark = new Gtk.Button ();
+            color_button_dark.halign = Gtk.Align.CENTER;
+            color_button_dark.height_request = 32;
+            color_button_dark.width_request = 32;
+            color_button_dark.tooltip_text = _("Solarized Dark");
+
+            var color_button_dark_context = color_button_dark.get_style_context ();
+            color_button_dark_context.add_class ("color-button");
+            color_button_dark_context.add_class ("color-dark");
+
+            var color_button_white = new Gtk.Button ();
+            color_button_white.halign = Gtk.Align.CENTER;
+            color_button_white.height_request = 32;
+            color_button_white.width_request = 32;
+            color_button_white.tooltip_text = _("High Contrast");
+
+            var color_button_white_context = color_button_white.get_style_context ();
+            color_button_white_context.add_class ("color-button");
+            color_button_white_context.add_class ("color-white");
 
             var style_popover_grid = new Gtk.Grid ();
             style_popover_grid.margin = 12;
-            style_popover_grid.orientation = Gtk.Orientation.VERTICAL;
-            style_popover_grid.row_spacing = 6;
+            style_popover_grid.column_spacing = 6;
+            style_popover_grid.row_spacing = 12;
             style_popover_grid.width_request = 200;
-            style_popover_grid.add (font_size_grid);
-            style_popover_grid.add (color_button);
+            style_popover_grid.attach (font_size_grid, 0, 0, 3, 1);
+            style_popover_grid.attach (color_button_light, 0, 1, 1, 1);
+            style_popover_grid.attach (color_button_dark, 1, 1, 1, 1);
+            style_popover_grid.attach (color_button_white, 2, 1, 1, 1);
             style_popover_grid.show_all ();
 
             var style_popover = new Gtk.Popover (null);
@@ -316,19 +363,22 @@ namespace PantheonTerminal {
             zoom_default_button.clicked.connect (() => action_zoom_default_font ());
             zoom_out_button.clicked.connect (() => action_zoom_out_font ());
 
-            color_button.mode_changed.connect (() => {
-                switch (color_button.selected) {
-                    case 0:
-                        settings.prefer_dark_style = false;
-                        settings.background = "rgba(253, 246, 227, 0.95)";
-                        settings.foreground = "#586e75";
-                        break;
-                    case 1:
-                        settings.prefer_dark_style = true;
-                        settings.background = "rgba(37, 46, 50, 0.95)";
-                        settings.foreground = "#94a3a5";
-                        break;
-                }
+            color_button_dark.clicked.connect (() => {
+                settings.prefer_dark_style = true;
+                settings.background = "rgba(37, 46, 50, 0.95)";
+                settings.foreground = "#94a3a5";
+            });
+
+            color_button_light.clicked.connect (() => {
+                settings.prefer_dark_style = false;
+                settings.background = "rgba(253, 246, 227, 0.95)";
+                settings.foreground = "#586e75";
+            });
+
+            color_button_white.clicked.connect (() => {
+                settings.prefer_dark_style = false;
+                settings.background = "#fff";
+                settings.foreground = "#333";
             });
 
             key_press_event.connect ((e) => {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -45,6 +45,13 @@ namespace PantheonTerminal {
         private bool is_fullscreen = false;
         private string[] saved_tabs;
 
+        private const string HIGH_CONTRAST_BG = "#fff";
+        private const string HIGH_CONTRAST_FG = "#333";
+        private const string SOLARIZED_DARK_BG = "rgba(37, 46, 50, 0.95)";
+        private const string SOLARIZED_DARK_FG = "#94a3a5";
+        private const string SOLARIZED_LIGHT_BG = "rgba(253, 246, 227, 0.95)";
+        private const string SOLARIZED_LIGHT_FG = "#586e75";
+
         const string BG_STYLE_CSS = """
             .terminal-window.background {
                 background-color: transparent;
@@ -365,20 +372,20 @@ namespace PantheonTerminal {
 
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;
-                settings.background = "rgba(37, 46, 50, 0.95)";
-                settings.foreground = "#94a3a5";
+                settings.background = SOLARIZED_DARK_BG;
+                settings.foreground = SOLARIZED_DARK_FG;
             });
 
             color_button_light.clicked.connect (() => {
                 settings.prefer_dark_style = false;
-                settings.background = "rgba(253, 246, 227, 0.95)";
-                settings.foreground = "#586e75";
+                settings.background = SOLARIZED_LIGHT_BG;
+                settings.foreground = SOLARIZED_LIGHT_FG;
             });
 
             color_button_white.clicked.connect (() => {
                 settings.prefer_dark_style = false;
-                settings.background = "#fff";
-                settings.foreground = "#333";
+                settings.background = HIGH_CONTRAST_BG;
+                settings.foreground = HIGH_CONTRAST_FG;
             });
 
             key_press_event.connect ((e) => {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -146,11 +146,9 @@ namespace PantheonTerminal {
                 app.set_accels_for_action (ACTION_PREFIX + action, action_accelerators[action].to_array ());
             }
 
-            var settings = Gtk.Settings.get_default ();
-            settings.gtk_application_prefer_dark_theme = true;
-
             /* Make GTK+ CSD not steal F10 from the terminal */
-            settings.gtk_menu_bar_accel = null;
+            var gtk_settings = Gtk.Settings.get_default ();
+            gtk_settings.gtk_menu_bar_accel = null;
 
             set_visual (Gdk.Screen.get_default ().get_rgba_visual ());
 
@@ -246,10 +244,17 @@ namespace PantheonTerminal {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
+            var color_button = new Granite.Widgets.ModeButton ();
+            color_button.append_text (_("Light"));
+            color_button.append_text (_("Dark"));
+
             var style_popover_grid = new Gtk.Grid ();
-            style_popover_grid.margin = 6;
+            style_popover_grid.margin = 12;
+            style_popover_grid.orientation = Gtk.Orientation.VERTICAL;
+            style_popover_grid.row_spacing = 6;
             style_popover_grid.width_request = 200;
             style_popover_grid.add (font_size_grid);
+            style_popover_grid.add (color_button);
             style_popover_grid.show_all ();
 
             var style_popover = new Gtk.Popover (null);
@@ -304,6 +309,21 @@ namespace PantheonTerminal {
             zoom_in_button.clicked.connect (() => action_zoom_in_font ());
             zoom_default_button.clicked.connect (() => action_zoom_default_font ());
             zoom_out_button.clicked.connect (() => action_zoom_out_font ());
+
+            color_button.mode_changed.connect (() => {
+                switch (color_button.selected) {
+                    case 0:
+                        settings.prefer_dark_style = false;
+                        settings.background = "rgba(253, 246, 227, 0.95)";
+                        settings.foreground = "#586e75";
+                        break;
+                    case 1:
+                        settings.prefer_dark_style = true;
+                        settings.background = "rgba(37, 46, 50, 0.95)";
+                        settings.foreground = "#94a3a5";
+                        break;
+                }
+            });
 
             key_press_event.connect ((e) => {
                 switch (e.keyval) {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -50,27 +50,33 @@ namespace PantheonTerminal {
             }
         """;
 
+        public SimpleActionGroup actions { get; construct; }
+
+        public const string ACTION_PREFIX = "win.";
+        public const string ACTION_CLOSE_TAB = "action_close_tab";
+        public const string ACTION_FULLSCREEN = "action_fullscreen";
+        public const string ACTION_NEW_TAB = "action_new_tab";
+        public const string ACTION_NEW_WINDOW = "action_new_window";
+        public const string ACTION_NEXT_TAB = "action_next_tab";
+        public const string ACTION_PREVIOUS_TAB = "action_previous_tab";
+        public const string ACTION_ZOOM_IN_FONT = "action_zoom_in_font";
+        public const string ACTION_ZOOM_OUT_FONT = "action_zoom_out_font";
+
+        private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
+
+        private const ActionEntry[] action_entries = {
+            { ACTION_CLOSE_TAB, action_close_tab },
+            { ACTION_FULLSCREEN, action_fullscreen },
+            { ACTION_NEW_TAB, action_new_tab },
+            { ACTION_NEW_WINDOW, action_new_window },
+            { ACTION_NEXT_TAB, action_next_tab },
+            { ACTION_PREVIOUS_TAB, action_previous_tab },
+            { ACTION_ZOOM_IN_FONT, action_zoom_in_font },
+            { ACTION_ZOOM_OUT_FONT, action_zoom_out_font }
+        };
+
         const string ui_string = """
             <ui>
-            <popup name="MenuItemTool">
-                <menuitem name="New window" action="New window"/>
-                <menuitem name="New tab" action="New tab"/>
-                <menuitem name="CloseTab" action="CloseTab"/>
-                <menuitem name="Copy" action="Copy"/>
-                <menuitem name="Paste" action="Paste"/>
-                <menuitem name="Select All" action="Select All"/>
-                <menuitem name="Search" action="Search"/>
-                <menuitem name="About" action="About"/>
-
-                <menuitem name="NextTab" action="NextTab"/>
-                <menuitem name="PreviousTab" action="PreviousTab"/>
-
-                <menuitem name="ZoomIn" action="ZoomIn"/>
-                <menuitem name="ZoomOut" action="ZoomOut"/>
-
-                <menuitem name="Fullscreen" action="Fullscreen"/>
-            </popup>
-
             <popup name="AppMenu">
                 <menuitem name="Copy" action="Copy"/>
                 <menuitem name="Paste" action="Paste"/>
@@ -102,6 +108,23 @@ namespace PantheonTerminal {
             new_tab (location);
         }
 
+        static construct {
+            action_accelerators[ACTION_CLOSE_TAB] = "<Control><Shift>w";
+            action_accelerators[ACTION_FULLSCREEN] = "F11";
+            action_accelerators[ACTION_NEW_TAB] = "<Control><Shift>t";
+            action_accelerators[ACTION_NEW_WINDOW] = "<Control><Shift>n";
+            action_accelerators[ACTION_NEXT_TAB] = "<Control><Shift>Right";
+            action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Left";
+            action_accelerators[ACTION_ZOOM_IN_FONT] = "<Control>plus";
+            action_accelerators[ACTION_ZOOM_OUT_FONT] = "<Control>minus";
+        }
+
+        construct {
+            actions = new SimpleActionGroup ();
+            actions.add_action_entries (action_entries, this);
+            insert_action_group ("win", actions);
+        }
+
         public void add_tab_with_command (string command) {
             new_tab ("", command);
         }
@@ -113,6 +136,10 @@ namespace PantheonTerminal {
         private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true) {
             icon_name = "utilities-terminal";
             set_application (app);
+
+            foreach (var action in action_accelerators.get_keys ()) {
+                app.set_accels_for_action (ACTION_PREFIX + action, action_accelerators[action].to_array ());
+            }
 
             var settings = Gtk.Settings.get_default ();
             settings.gtk_application_prefer_dark_theme = true;
@@ -983,60 +1010,11 @@ namespace PantheonTerminal {
         }
 
         static const Gtk.ActionEntry[] main_entries = {
-            { "CloseTab", "gtk-close", N_("Close"),
-              "<Control><Shift>w", N_("Close"),
-              action_close_tab },
-
-            { "New window", "window-new",
-              N_("New Window"), "<Control><Shift>n", N_("Open a new window"),
-              action_new_window },
-
-            { "New tab", "gtk-new",
-              N_("New Tab"), "<Control><Shift>t", N_("Create a new tab"),
-              action_new_tab },
-
-            { "Copy", "gtk-copy",
-              N_("Copy"), "<Control><Shift>c", N_("Copy the selected text"),
-              action_copy },
-
-            { "Search", "edit-find",
-              N_("Find…"), "<Control><Shift>f",
-              N_("Search for a given string in the terminal"), action_search },
-
-            { "Paste", "gtk-paste",
-              N_("Paste"), "<Control><Shift>v", N_("Paste some text"),
-              action_paste },
-
-            { "Select All", "gtk-select-all",
-              N_("Select All"), "<Control><Shift>a",
-              N_("Select all the text in the terminal"), action_select_all },
-
-            { "Show in File Browser", "gtk-directory",
-              N_("Show in File Browser"), "<Control><Shift>e",
-              N_("Open current location in Files"), action_open_in_files },
-
-            { "About", "gtk-about", N_("About"),
-              null, N_("Show about window"), action_about },
-
-            { "NextTab", null, N_("Next Tab"),
-              "<Control><Shift>Right", N_("Go to next tab"),
-              action_next_tab },
-
-            { "PreviousTab", null, N_("Previous Tab"),
-              "<Control><Shift>Left", N_("Go to previous tab"),
-              action_previous_tab },
-
-            { "ZoomIn", "gtk-zoom-in", N_("Zoom in"),
-              "<Control>plus", N_("Zoom in"),
-              action_zoom_in_font },
-
-            { "ZoomOut", "gtk-zoom-out",
-              N_("Zoom out"), "<Control>minus", N_("Zoom out"),
-              action_zoom_out_font },
-
-            { "Fullscreen", "gtk-fullscreen",
-              N_("Fullscreen"), "F11", N_("Toggle/Untoggle fullscreen"),
-              action_fullscreen }
+            { "Copy", null, N_("Copy"), "<Control><Shift>c", null, action_copy },
+            { "Search", null, N_("Find…"), "<Control><Shift>f", null, action_search },
+            { "Paste", null, N_("Paste"), "<Control><Shift>v", null, action_paste },
+            { "Select All", null, N_("Select All"), "<Control><Shift>a", null, action_select_all },
+            { "Show in File Browser", null, N_("Show in File Browser"), "<Control><Shift>e", null, action_open_in_files }
         };
     }
 }

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -269,6 +269,16 @@ namespace PantheonTerminal {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
+            var color_button_white = new Gtk.Button ();
+            color_button_white.halign = Gtk.Align.CENTER;
+            color_button_white.height_request = 32;
+            color_button_white.width_request = 32;
+            color_button_white.tooltip_text = _("High Contrast");
+
+            var color_button_white_context = color_button_white.get_style_context ();
+            color_button_white_context.add_class ("color-button");
+            color_button_white_context.add_class ("color-white");
+
             var color_button_light = new Gtk.Button ();
             color_button_light.halign = Gtk.Align.CENTER;
             color_button_light.height_request = 32;
@@ -289,25 +299,15 @@ namespace PantheonTerminal {
             color_button_dark_context.add_class ("color-button");
             color_button_dark_context.add_class ("color-dark");
 
-            var color_button_white = new Gtk.Button ();
-            color_button_white.halign = Gtk.Align.CENTER;
-            color_button_white.height_request = 32;
-            color_button_white.width_request = 32;
-            color_button_white.tooltip_text = _("High Contrast");
-
-            var color_button_white_context = color_button_white.get_style_context ();
-            color_button_white_context.add_class ("color-button");
-            color_button_white_context.add_class ("color-white");
-
             var style_popover_grid = new Gtk.Grid ();
             style_popover_grid.margin = 12;
             style_popover_grid.column_spacing = 6;
             style_popover_grid.row_spacing = 12;
             style_popover_grid.width_request = 200;
             style_popover_grid.attach (font_size_grid, 0, 0, 3, 1);
-            style_popover_grid.attach (color_button_light, 0, 1, 1, 1);
-            style_popover_grid.attach (color_button_dark, 1, 1, 1, 1);
-            style_popover_grid.attach (color_button_white, 2, 1, 1, 1);
+            style_popover_grid.attach (color_button_white, 0, 1, 1, 1);
+            style_popover_grid.attach (color_button_light, 1, 1, 1, 1);
+            style_popover_grid.attach (color_button_dark, 2, 1, 1, 1);
             style_popover_grid.show_all ();
 
             var style_popover = new Gtk.Popover (null);

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -57,6 +57,7 @@ namespace PantheonTerminal {
         public bool alt_changes_tab { get; set; }
         public bool audible_bell { get; set; }
         public bool natural_copy_paste { get; set; }
+        public bool prefer_dark_style { get; set; }
         public bool unsafe_paste_alert { get; set; }
 
         public string foreground { get; set; }

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -178,16 +178,21 @@ namespace PantheonTerminal {
 
         public void restore_settings () {
             /* Load configuration */
+            var  gtk_settings = Gtk.Settings.get_default ();
+            gtk_settings.gtk_application_prefer_dark_theme = settings.prefer_dark_style;
+
             Gdk.RGBA background_color = Gdk.RGBA ();
             background_color.parse (settings.background);
 
             Gdk.RGBA foreground_color = Gdk.RGBA ();
             foreground_color.parse (settings.foreground);
 
-            string[] hex_palette = { "#000000", "#FF6C60", "#A8FF60", "#FFFFCC", "#96CBFE",
-                                     "#FF73FE", "#C6C5FE", "#EEEEEE", "#000000", "#FF6C60",
-                                     "#A8FF60", "#FFFFB6", "#96CBFE", "#FF73FE", "#C6C5FE",
-                                     "#EEEEEE" };
+            string[] hex_palette = {
+                "#073642", "#dc322f", "#859900", "#b58900",
+                "#268bd2", "#ec0048", "#2aa198", "#94a3a5",
+                "#586e75", "#cb4b16", "#859900", "#b58900",
+                "#268bd2", "#d33682", "#2aa198", "#6c71c4"
+            };
 
             string current_string = "";
             int current_color = 0;

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -178,7 +178,7 @@ namespace PantheonTerminal {
 
         public void restore_settings () {
             /* Load configuration */
-            var  gtk_settings = Gtk.Settings.get_default ();
+            var gtk_settings = Gtk.Settings.get_default ();
             gtk_settings.gtk_application_prefer_dark_theme = settings.prefer_dark_style;
 
             Gdk.RGBA background_color = Gdk.RGBA ();


### PR DESCRIPTION
Adds a setting for Dark/Light/High Contrast style Fixes #147

* Reformatted the hex_palette array and use colors from default gsettings
* Added a setting for gtk_prefer_dark and restore it on app startup
* Set prefer_dark, foreground, and background colors from the popover

![screenshot from 2017-11-10 15 53 20](https://user-images.githubusercontent.com/7277719/32683332-57bd2212-c62f-11e7-9128-76f1e2f14e3c.png)

