### PR TITLE
Findbar tweaks

### DIFF
--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -32,11 +32,11 @@ namespace PantheonTerminal.Widgets {
             search_entry.hexpand = true;
             search_entry.placeholder_text = _("Find");
 
-            var previous_button = new Gtk.Button.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            var previous_button = new Gtk.Button.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             previous_button.sensitive = false;
             previous_button.tooltip_text = _("Previous result");
 
-            var next_button = new Gtk.Button.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            var next_button = new Gtk.Button.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             next_button.sensitive = false;
             next_button.tooltip_text = _("Next result");
 
@@ -44,8 +44,8 @@ namespace PantheonTerminal.Widgets {
             search_grid.margin = 3;
             search_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
             search_grid.add (search_entry);
-            search_grid.add (previous_button);
             search_grid.add (next_button);
+            search_grid.add (previous_button);
 
             add (search_grid);
             get_style_context ().add_class ("search-bar");

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -19,36 +19,35 @@
 
 namespace PantheonTerminal.Widgets {
 
-    public class SearchToolbar : Gtk.Toolbar {
+    public class SearchToolbar : Gtk.Grid {
         public weak PantheonTerminalWindow window { get; construct; }
         public Gtk.SearchEntry search_entry;
 
         public SearchToolbar (PantheonTerminalWindow window) {
-            Object (
-                icon_size: Gtk.IconSize.SMALL_TOOLBAR,
-                window: window
-            );
+            Object (window: window);
         }
 
         construct {
             search_entry = new Gtk.SearchEntry ();
+            search_entry.hexpand = true;
             search_entry.placeholder_text = _("Find");
-            search_entry.width_request = 250;
-            search_entry.margin_left = 6;
 
-            var tool_search_entry = new Gtk.ToolItem ();
-            tool_search_entry.add (search_entry);
-
-            var previous_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR), null);
+            var previous_button = new Gtk.Button.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            previous_button.sensitive = false;
             previous_button.tooltip_text = _("Previous result");
 
-            var next_button = new Gtk.ToolButton (new Gtk.Image.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR), null);
+            var next_button = new Gtk.Button.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
+            next_button.sensitive = false;
             next_button.tooltip_text = _("Next result");
 
-            add (tool_search_entry);
-            add (previous_button);
-            add (next_button);
+            var search_grid = new Gtk.Grid ();
+            search_grid.margin = 3;
+            search_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+            search_grid.add (search_entry);
+            search_grid.add (previous_button);
+            search_grid.add (next_button);
 
+            add (search_grid);
             get_style_context ().add_class ("search-bar");
             show_all ();
 
@@ -57,6 +56,14 @@ namespace PantheonTerminal.Widgets {
             });
 
             search_entry.search_changed.connect (() => {
+                if (search_entry.text != "") {
+                    previous_button.sensitive = true;
+                    next_button.sensitive = true;
+                } else {
+                    previous_button.sensitive = false;
+                    next_button.sensitive = false;
+                }
+
                 try {
                     // FIXME Have a configuration menu or something.
                     var regex = new Regex (Regex.escape_string (search_entry.text), RegexCompileFlags.CASELESS);


### PR DESCRIPTION
This branch is meant to bring the behavior of the findbar in Terminal more in line with the findbar in Code:

* Hexpand the search entry
* Put buttons in a linked container
* Put buttons in the same order as Code
* Only make next and previous buttons sensitive when the entry has text in it

![screenshot from 2017-11-18 11 13 32](https://user-images.githubusercontent.com/7277719/32983982-2394767e-cc52-11e7-9e5c-6ec5ed54cc8c.png)
