### PR TITLE
PantheonTerminalWindow.vala: make Gdk.Atom nullable

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -597,8 +597,7 @@ namespace PantheonTerminal {
             clipboard.request_targets (update_context_menu_cb);
         }
 
-        private void update_context_menu_cb (Gtk.Clipboard clipboard_,
-                                             Gdk.Atom[] atoms) {
+        private void update_context_menu_cb (Gtk.Clipboard clipboard_, Gdk.Atom[]? atoms) {
             bool can_paste = false;
 
             if (atoms != null && atoms.length > 0)


### PR DESCRIPTION
Fixes #182 