### PR TITLE
Restore tabs when starting with a directory

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -182,7 +182,7 @@ namespace PantheonTerminal {
                 window.add_tab_with_working_directory (working_directory);
                 window.present ();
             } else
-                new PantheonTerminalWindow.with_working_directory (this, working_directory, false);
+                new PantheonTerminalWindow.with_working_directory (this, working_directory, true);
         }
 
         private PantheonTerminalWindow? get_last_window () {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -43,6 +43,7 @@ namespace PantheonTerminal {
 
         public TerminalWidget current_terminal = null;
         private bool is_fullscreen = false;
+        public bool focus_restored_tabs { get; construct; default = true; }
         private string[] saved_tabs;
 
         private const string HIGH_CONTRAST_BG = "#fff";
@@ -108,7 +109,11 @@ namespace PantheonTerminal {
 
         public PantheonTerminalWindow.with_working_directory (PantheonTerminalApp app, string location,
                                                               bool should_recreate_tabs = true) {
-            init (app, should_recreate_tabs, true, false);
+            Object (
+                focus_restored_tabs: false
+            );
+
+            init (app, should_recreate_tabs);
             new_tab (location);
         }
 
@@ -137,7 +142,7 @@ namespace PantheonTerminal {
             new_tab (location);
         }
 
-        private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true, bool focus_tabs = true) {
+        private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true) {
             icon_name = "utilities-terminal";
 
             set_application (app);
@@ -155,7 +160,7 @@ namespace PantheonTerminal {
             title = TerminalWidget.DEFAULT_LABEL;
             restore_saved_state (restore_pos);
             if (recreate_tabs) {
-                open_tabs (focus_tabs);
+                open_tabs ();
             }
 
             /* Actions and UIManager */
@@ -660,7 +665,7 @@ namespace PantheonTerminal {
             new_tab.page.grab_focus ();
         }
 
-        private void open_tabs (bool focus = true) {
+        private void open_tabs () {
             string[] tabs = {};
             if (settings.remember_tabs) {
                 tabs = saved_tabs;
@@ -692,7 +697,7 @@ namespace PantheonTerminal {
                     /* Schedule tab to be added when idle (helps to avoid corruption of
                      * prompt on startup with multiple tabs) */
                     Idle.add_full (GLib.Priority.LOW, () => {
-                        new_tab (loc, null, focus);
+                        new_tab (loc, null, focus_restored_tabs);
                         return false;
                     });
                 }

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -108,7 +108,7 @@ namespace PantheonTerminal {
 
         public PantheonTerminalWindow.with_working_directory (PantheonTerminalApp app, string location,
                                                               bool should_recreate_tabs = true) {
-            init (app, should_recreate_tabs);
+            init (app, should_recreate_tabs, true, false);
             new_tab (location);
         }
 
@@ -137,7 +137,7 @@ namespace PantheonTerminal {
             new_tab (location);
         }
 
-        private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true) {
+        private void init (PantheonTerminalApp app, bool recreate_tabs = true, bool restore_pos = true, bool focus_tabs = true) {
             icon_name = "utilities-terminal";
 
             set_application (app);
@@ -155,7 +155,7 @@ namespace PantheonTerminal {
             title = TerminalWidget.DEFAULT_LABEL;
             restore_saved_state (restore_pos);
             if (recreate_tabs) {
-                open_tabs ();
+                open_tabs (focus_tabs);
             }
 
             /* Actions and UIManager */
@@ -660,7 +660,7 @@ namespace PantheonTerminal {
             new_tab.page.grab_focus ();
         }
 
-        private void open_tabs () {
+        private void open_tabs (bool focus = true) {
             string[] tabs = {};
             if (settings.remember_tabs) {
                 tabs = saved_tabs;
@@ -692,14 +692,14 @@ namespace PantheonTerminal {
                     /* Schedule tab to be added when idle (helps to avoid corruption of
                      * prompt on startup with multiple tabs) */
                     Idle.add_full (GLib.Priority.LOW, () => {
-                        new_tab (loc);
+                        new_tab (loc, null, focus);
                         return false;
                     });
                 }
             }
         }
 
-        private void new_tab (string directory, string? program = null) {
+        private void new_tab (string directory, string? program = null, bool focus = true) {
             /*
              * If the user choose to use a specific working directory.
              * Reassigning the directory variable a new value
@@ -764,8 +764,11 @@ namespace PantheonTerminal {
             set_geometry_hints (this, hints, Gdk.WindowHints.RESIZE_INC);
 
             notebook.insert_tab (tab, -1);
-            notebook.current = tab;
-            t.grab_focus ();
+
+            if (focus) {
+                notebook.current = tab;
+                t.grab_focus ();
+            }
 
             if (program == null) {
                 /* Set up the virtual terminal */


### PR DESCRIPTION
Restores tabs when opening Terminal with a directory, this tab however would not gain focus as tab restores are done at full idle. To ensure the tab correctly grabs focus the tab restore and subsequently create functions had to be modified so they had a parameter to define whether they would grab focus.

Fixes #62 