### PR TITLE
Restore tab focus

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -34,8 +34,13 @@
     </key>
     <key name="tabs" type="as">
       <default>[]</default>
-      <summary>List of tabs which were active when the window was closed</summary>
-      <description>List of tabs which were active when the window was closed</description>
+      <summary>List of tabs from the last active window.</summary>
+      <description>List of tabs from the last active window.</description>
+    </key>
+    <key name="focused-tab" type="i">
+        <default>-1</default>
+        <summary>The index of the tab that is focused.</summary>
+        <description>The index of the tab from the saved tabs that is currently focused.</description>
     </key>
     <key name="opening-x" type="i">
       <default>-1</default>

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -695,7 +695,7 @@ namespace PantheonTerminal {
                     }
                 }
 
-                if (focus_restored_tabs && focus == i) {
+                if (focus_restored_tabs && focus == tabs.length) {
                     var t = notebook.get_tab_by_index (notebook.n_tabs - 1);
                     notebook.current = t;
                     t.grab_focus ();

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -648,7 +648,7 @@ namespace PantheonTerminal {
             new_tab.icon = null;
             new_tab.page.grab_focus ();
 
-            PantheonTerminal.saved_state.focused_tab = notebook.get_tab_position(new_tab);
+            PantheonTerminal.saved_state.focused_tab = notebook.get_tab_position (new_tab);
         }
 
         private void open_tabs () {
@@ -678,25 +678,20 @@ namespace PantheonTerminal {
 
             PantheonTerminal.saved_state.tabs = {};
 
-            int focus = 0 <= PantheonTerminal.saved_state.focused_tab < tabs.length
-                            ? PantheonTerminal.saved_state.focused_tab : tabs.length - 1;
+            int focus = PantheonTerminal.saved_state.focused_tab.clamp(0, tabs.length - 1);
             Idle.add_full (GLib.Priority.LOW, () => {
-                int i;
-                for (i = 0; i < tabs.length; i++) {
-                    if (tabs[i] == "") {
-                        if (i == focus) {
-                            focus++;
-                        }
+                focus += notebook.n_tabs;
+                foreach (string loc in tabs) {
+                    if (loc == "") {
+                        focus--;
                         continue;
-                    } else if (focus == i) {
-                        new_tab (tabs[i], null, focus_restored_tabs);
                     } else {
-                        new_tab (tabs[i], null, false);
+                        new_tab (loc, null, false);
                     }
                 }
 
-                if (focus_restored_tabs && focus == tabs.length) {
-                    var t = notebook.get_tab_by_index (notebook.n_tabs - 1);
+                if (focus_restored_tabs) {
+                    var t = notebook.get_tab_by_index (focus.clamp (0, notebook.n_tabs - 1));
                     notebook.current = t;
                     t.grab_focus ();
                 }
@@ -1063,7 +1058,7 @@ namespace PantheonTerminal {
             });
 
             PantheonTerminal.saved_state.tabs = opened_tabs;
-            PantheonTerminal.saved_state.focused_tab = notebook.get_tab_position(notebook.current);
+            PantheonTerminal.saved_state.focused_tab = notebook.get_tab_position (notebook.current);
         }
 
         /** Return enough of @path to distinguish it from @conflict_path **/

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -40,6 +40,7 @@ namespace PantheonTerminal {
         public int window_height { get; set; }
         public PantheonTerminalWindowState window_state { get; set; }
         public string[] tabs { get; set; }
+        public int focused_tab { get; set; }
         public int opening_x { get; set; }
         public int opening_y { get; set; }
         public double zoom { get; set; }


### PR DESCRIPTION
Adds a new key to save to index of the focused tab so that when restoring tabs it will be focused to the correct tab (if the tabs are set to restore focus.)

Fixes #12 