### PR TITLE
Save tabs when terminal is closed

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -815,6 +815,7 @@ namespace PantheonTerminal {
 
         protected override bool delete_event (Gdk.EventAny event) {
             action_quit ();
+            save_opened_terminals ();
             var tabs_to_terminate = new GLib.List <TerminalWidget> ();
 
             foreach (var t in terminals) {


### PR DESCRIPTION
This call could not actually be removed without breaking behaviour. This ensures the last closed terminal window is saved rather than the last active.