### PR TITLE
Allow not ensuring tab existence for new window with coord

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -68,8 +68,8 @@ namespace PantheonTerminal {
             }
         }
 
-        public PantheonTerminalWindow new_window_with_coords (int x, int y, bool should_recreate_tabs=true) {
-            var window = new PantheonTerminalWindow.with_coords (this, x, y, should_recreate_tabs);
+        public PantheonTerminalWindow new_window_with_coords (int x, int y, bool should_recreate_tabs=true, bool ensure_tab=true) {
+            var window = new PantheonTerminalWindow.with_coords (this, x, y, should_recreate_tabs, ensure_tab);
 
             return window;
         }

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -68,7 +68,7 @@ namespace PantheonTerminal {
             }
         }
 
-        public PantheonTerminalWindow new_window_with_coords (int x, int y, bool should_recreate_tabs=true, bool ensure_tab=true) {
+        public PantheonTerminalWindow new_window_with_coords (int x, int y, bool should_recreate_tabs = true, bool ensure_tab = false) {
             var window = new PantheonTerminalWindow.with_coords (this, x, y, should_recreate_tabs, ensure_tab);
 
             return window;

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -100,7 +100,8 @@ namespace PantheonTerminal {
             }
         }
 
-        public PantheonTerminalWindow.with_coords (PantheonTerminalApp app, int x, int y, bool recreate_tabs = true) {
+        public PantheonTerminalWindow.with_coords (PantheonTerminalApp app, int x, int y,
+                                                   bool recreate_tabs = true, bool ensure_tab = true) {
             Object (
                 app: app,
                 restore_pos: false,
@@ -109,7 +110,7 @@ namespace PantheonTerminal {
 
             move (x, y);
 
-            if (!recreate_tabs) {
+            if (!recreate_tabs && ensure_tab) {
                 new_tab ("");
             }
         }
@@ -563,7 +564,7 @@ namespace PantheonTerminal {
 
         private void on_tab_moved (Granite.Widgets.Tab tab, int x, int y) {
             Idle.add (() => {
-                var new_window = app.new_window_with_coords (x, y, false);
+                var new_window = app.new_window_with_coords (x, y, false, false);
                 var t = get_term_widget (tab);
                 var new_notebook = new_window.notebook;
 

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -101,7 +101,7 @@ namespace PantheonTerminal {
         }
 
         public PantheonTerminalWindow.with_coords (PantheonTerminalApp app, int x, int y,
-                                                   bool recreate_tabs = true, bool ensure_tab = true) {
+                                                   bool recreate_tabs, bool ensure_tab) {
             Object (
                 app: app,
                 restore_pos: false,
@@ -564,7 +564,7 @@ namespace PantheonTerminal {
 
         private void on_tab_moved (Granite.Widgets.Tab tab, int x, int y) {
             Idle.add (() => {
-                var new_window = app.new_window_with_coords (x, y, false, false);
+                var new_window = app.new_window_with_coords (x, y, false);
                 var t = get_term_widget (tab);
                 var new_notebook = new_window.notebook;
 


### PR DESCRIPTION
When creating a new window with coord it always attempted to create a tab if none existed (from #189) as no tab existing breaks the window, this adds a parameter to not ensure this, for if a tab will be created later.

Fixes #199 