### PR TITLE
Fix make pot command

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -3,8 +3,8 @@ add_translations_directory (${GETTEXT_PACKAGE})
 add_translations_catalog (${GETTEXT_PACKAGE}
     ../src
     DESKTOP_FILES
-        ${CMAKE_SOURCE_DIR}/data/open-pantheon-terminal-here.desktop.in
-        ${CMAKE_SOURCE_DIR}/data/org.pantheon.terminal.desktop.in
+        ${CMAKE_SOURCE_DIR}/data/open-pantheon-terminal-here.desktop.in.in
+        ${CMAKE_SOURCE_DIR}/data/io.elementary.terminal.desktop.in.in
     APPDATA_FILES
         ${CMAKE_SOURCE_DIR}/data/io.elementary.terminal.appdata.xml.in
 )


### PR DESCRIPTION
Make pot command didn't work, this updates the file names of the desktop files to correct this.