### PR TITLE
Allow several completion notifications to coexist

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -119,7 +119,7 @@ namespace PantheonTerminal {
                                     var notification = new Notification (_("Task finished"));
                                     notification.set_body (process);
                                     notification.set_icon (new ThemedIcon ("utilities-terminal"));
-                                    send_notification ("finished", notification);
+                                    send_notification (null, notification);
                                 }
                             }
 


### PR DESCRIPTION
Do not set notification ID so that several notifications about process completion can coexist. Fixes #221

Reference: https://valadoc.org/gio-2.0/GLib.Application.send_notification.html