### PR TITLE
Remove icons from .desktop actions

### DIFF
--- a/data/io.elementary.terminal.desktop.in
+++ b/data/io.elementary.terminal.desktop.in
@@ -14,10 +14,8 @@ Actions=NewWindow;NewRootWindow;
 
 [Desktop Action NewWindow]
 Name=New Window
-Icon=utilities-terminal
 Exec=io.elementary.terminal
 
 [Desktop Action NewRootWindow]
 Name=New Root Tab
-Icon=utilities-terminal
 Exec=io.elementary.terminal -e "sudo -s"


### PR DESCRIPTION
These icons show in plank and they don't really add anything here. It looks silly to have the same two icons for both actions