### PR TITLE
update to Gtk.Application

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -18,7 +18,7 @@
 */
 
 namespace PantheonTerminal {
-    public class PantheonTerminalApp : Granite.Application {
+    public class PantheonTerminalApp : Gtk.Application {
 
         private GLib.List <PantheonTerminalWindow> windows;
 


### PR DESCRIPTION
`Granite.Application` is deprecated so let's switch to `Gtk.Application`

Just a quick one line change as this doesn't seem to break anything, let me know if there's anything I need to add.