### PR TITLE
Do not restore tabs when opened with commandline -w parameter

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -173,7 +173,7 @@ namespace PantheonTerminal {
                 window.add_tab_with_working_directory (working_directory);
                 window.present ();
             } else
-                new PantheonTerminalWindow.with_working_directory (this, working_directory, true);
+                new PantheonTerminalWindow.with_working_directory (this, working_directory);
         }
 
         private PantheonTerminalWindow? get_last_window () {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -122,7 +122,8 @@ namespace PantheonTerminal {
                 app: app,
                 focus_restored_tabs: false,
                 recreate_tabs: recreate_tabs,
-                save_tabs: recreate_tabs
+                save_tabs: recreate_tabs,
+                title: location
             );
 
             new_tab (location);
@@ -163,6 +164,7 @@ namespace PantheonTerminal {
             set_visual (Gdk.Screen.get_default ().get_rgba_visual ());
 
             title = TerminalWidget.DEFAULT_LABEL;
+
             restore_saved_state (restore_pos);
             if (recreate_tabs) {
                 open_tabs ();
@@ -751,9 +753,10 @@ namespace PantheonTerminal {
              * set its title. So we cannot detect path changes in the shell. Tab name remains "Terminal".
              */
             t.window_title_changed.connect (() => {
-                if (t == current_terminal) {
+                if (t == current_terminal && t.window_title != "") {
                     title = t.window_title;
                 }
+
                 schedule_name_check ();
             });
 
@@ -1010,6 +1013,17 @@ namespace PantheonTerminal {
 
         /** Compare every tab label with every other and resolve ambiguities **/
         private bool check_for_tabs_with_same_name () {
+            /* Ensure tab has proper label when opened from commandline) */
+            if (terminals.length () == 1) {
+                var terminal = terminals.first ().data;
+                title = terminal.get_shell_location ();
+                if (title != "") {
+                    terminal.tab_label = Path.get_basename (title);
+                }
+
+                return true;
+            }
+
             /* Take list copies so foreach clauses can be nested safely*/
             var terms = terminals.copy ();
             var terms2 = terminals.copy ();

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -43,6 +43,7 @@ namespace PantheonTerminal {
         public bool unsafe_ignored;
         public bool focus_restored_tabs { get; construct; default = true; }
         public bool recreate_tabs { get; construct; default = true; }
+        public bool save_tabs { get; construct; default = true; }
         public bool restore_pos { get; construct; default = true; }
         public Gtk.UIManager ui { get; private set; }
         public PantheonTerminalApp app { get; construct; }
@@ -120,7 +121,8 @@ namespace PantheonTerminal {
             Object (
                 app: app,
                 focus_restored_tabs: false,
-                recreate_tabs: recreate_tabs
+                recreate_tabs: recreate_tabs,
+                save_tabs: recreate_tabs
             );
 
             new_tab (location);
@@ -1048,6 +1050,10 @@ namespace PantheonTerminal {
         }
 
         private void save_opened_terminals () {
+            if (!save_tabs) {
+                return;
+            }
+
             string[] opened_tabs = {};
 
             notebook.tabs.foreach ((tab) => {

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -48,7 +48,7 @@ namespace PantheonTerminal {
         public PantheonTerminalApp app { get; construct; }
         public SimpleActionGroup actions { get; construct; }
         public TerminalWidget current_terminal { get; private set; default = null; }
-        
+
         public GLib.List <TerminalWidget> terminals = new GLib.List <TerminalWidget> ();
         public Gtk.ActionGroup main_actions;
 
@@ -116,7 +116,7 @@ namespace PantheonTerminal {
         }
 
         public PantheonTerminalWindow.with_working_directory (PantheonTerminalApp app, string location,
-                                                              bool recreate_tabs = true) {
+                                                              bool recreate_tabs = false) {
             Object (
                 app: app,
                 focus_restored_tabs: false,


### PR DESCRIPTION
Partly addresses issue #233.

The constructor `PantheonTerminalWindow.with_working_directory () now does not restore tabs nor does it save tabs when exiting.

This fixes the linked issue with respect to opening from Files.

Opening from Plank will be another PR.