### PR TITLE
Do not restore tabs in new window from Plank.

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -19,7 +19,6 @@
 
 namespace PantheonTerminal {
     public class PantheonTerminalApp : Gtk.Application {
-
         private GLib.List <PantheonTerminalWindow> windows;
 
         public static string? working_directory = null;
@@ -32,6 +31,7 @@ namespace PantheonTerminal {
 
         construct {
             flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
+            application_id = "io.elementary.terminal";  /* Ensures only one instance runs */
 
             Intl.setlocale (LocaleCategory.ALL, "");
         }


### PR DESCRIPTION
Fixes #233

 with respect to opening second window from Plank.

The application_id is set to ensure only one instance of the application is run, fixing regression caused by #229 