### PR TITLE
Add back app ID

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -34,6 +34,8 @@ namespace PantheonTerminal {
             flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
 
             Intl.setlocale (LocaleCategory.ALL, "");
+
+            application_id = "io.elementary.terminal";
         }
 
         public PantheonTerminalApp () {


### PR DESCRIPTION
Accidentally removed when we ported to Meson. Fixes #236 