### PR TITLE
Make Terminal opaque when tiled

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -20,7 +20,8 @@
     background-color: transparent;
 }
 
-.terminal-window.background.maximized {
+.terminal-window.background.maximized,
+.terminal-window.background.tiled {
     background-color: #000;
 }
 


### PR DESCRIPTION
Because of rounded corners in tiles now and light bleed in those corners