### PR TITLE
Update FISH integration for the new D-bus API and enable it by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To install, use `ninja install`, then execute with `io.elementary.terminal`
 
 ## Notifications
 
-Terminal implements process completion notifications. They are enabled for BASH automatically. To enable them for ZSH, add the following line to .zshrc:
+Terminal implements process completion notifications. They are enabled for BASH and FISH automatically. To enable them for ZSH, add the following line to .zshrc:
 
     builtin . /usr/share/io.elementary.terminal/enable-zsh-completion-notifications || builtin true
 

--- a/data/meson.build
+++ b/data/meson.build
@@ -51,8 +51,8 @@ test (
 )
 
 install_data(
-    'enable-fish-completion-notifications',
-    install_dir: join_paths(get_option('datadir'), meson.project_name())
+    'pantheon_terminal_process_completion_notifications.fish',
+    install_dir: join_paths(get_option('datadir'), 'fish', 'vendor_conf.d')
 )
 
 install_data(

--- a/data/pantheon_terminal_process_completion_notifications.fish
+++ b/data/pantheon_terminal_process_completion_notifications.fish
@@ -1,22 +1,17 @@
-# This file should be sourced from either /etc/fish/config.fish
-# or ~/.config/fish/config.fish in order to enable 
-# process completion notifications in Pantheon Terminal.
-# Like this:
-#source /usr/share/io.elementary.terminal/enable-fish-completion-notifications 2>/dev/null; or true
-
-# If you come up with a way to inject this without modifying those files,
-# please let me know at <sergey@elementaryos.org>
+# This file provides notifications about command completion to Pantheon Terminal,
+# which displays desktop notifications and/or tab icons, if appropriate.
 
 function pantheon-terminal-process-completion-callback --on-event fish_postexec --description "Notify Pantheon Terminal about task completion"
+    set cmd_exit_status $status
     if status --is-interactive; and set --query PANTHEON_TERMINAL_ID
-        dbus-send --type=method_call --session --dest=io.elementary.terminal /io/elementary/terminal io.elementary.terminal.ProcessFinished string:$PANTHEON_TERMINAL_ID string:"$argv[1]";
+        dbus-send --type=method_call --session --dest=io.elementary.terminal /io/elementary/terminal io.elementary.terminal.ProcessFinished string:$PANTHEON_TERMINAL_ID string:"$argv[1]" int32:$cmd_exit_status;
     end
 end
 
 # Some shells (e.g. BASH) lack the post-execution hook,
 # so we insert a callback into their pre-prompt hook instead.
 # This results in a bogus callback on first prompt, which has to be ignored.
-# I've tried some clever focus-based suppression but it was prone to race conditions.
+# We've tried some clever focus-based suppression but it was prone to race conditions.
 # The only reliable way to work that around that we've found
 # is always ignoring the first callback in each tab on the terminal side
 # and deliberately issuing a fake callback from shells with a proper


### PR DESCRIPTION
 - Update FISH integration to new D-bus API (#214)
 - Put the post-exec hook in a designated directory for vendor config, so the user no longer has to edit any config files to get it to work. Vendor config is available starting with FISH version 2.3; Juno ships with 2.7