### PR TITLE
Do not allow focus menu and search buttons

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -48,7 +48,7 @@ namespace PantheonTerminal {
         public PantheonTerminalApp app { get; construct; }
         public SimpleActionGroup actions { get; construct; }
         public TerminalWidget current_terminal { get; private set; default = null; }
-        
+
         public GLib.List <TerminalWidget> terminals = new GLib.List <TerminalWidget> ();
         public Gtk.ActionGroup main_actions;
 
@@ -348,6 +348,10 @@ namespace PantheonTerminal {
             get_style_context ().add_class ("terminal-window");
             set_titlebar (header);
             add (grid);
+
+            style_popover.closed.connect_after (() => {
+                current_terminal.grab_focus ();
+            });
 
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -304,6 +304,7 @@ namespace PantheonTerminal {
             style_popover.add (style_popover_grid);
 
             var style_button = new Gtk.MenuButton ();
+            style_button.set_can_focus (false);
             style_button.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             style_button.popover = style_popover;
             style_button.tooltip_text = _("Style");
@@ -348,10 +349,6 @@ namespace PantheonTerminal {
             get_style_context ().add_class ("terminal-window");
             set_titlebar (header);
             add (grid);
-
-            style_popover.closed.connect_after (() => {
-                current_terminal.grab_focus ();
-            });
 
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -35,15 +35,18 @@ namespace PantheonTerminal.Widgets {
 
             var previous_button = new Gtk.Button.from_icon_name ("go-up-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             previous_button.sensitive = false;
+            previous_button.set_can_focus (false);
             previous_button.tooltip_text = _("Previous result");
 
             var next_button = new Gtk.Button.from_icon_name ("go-down-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             next_button.sensitive = false;
+            next_button.set_can_focus (false);
             next_button.tooltip_text = _("Next result");
 
             cycle_button = new Gtk.ToggleButton ();
             cycle_button.image =  new Gtk.Image.from_icon_name ("media-playlist-repeat-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             cycle_button.sensitive = false;
+            cycle_button.set_can_focus (false);
             cycle_button.tooltip_text = _("Cyclic search");
 
             var search_grid = new Gtk.Grid ();


### PR DESCRIPTION
Fixes #241 

This is a simple fix, but note that it could have accessibility implications unless hot-keys are provided for the buttons affected.