### PR TITLE
Refactor TerminalWindow actions and menu

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -969,6 +969,18 @@ namespace PantheonTerminal {
             search_button.active = !search_button.active;
         }
 
+        void action_search_next () {
+            if (search_button.active) {
+                search_toolbar.next_search ();
+            }
+        }
+
+        void action_search_previous () {
+            if (search_button.active) {
+                search_toolbar.previous_search ();
+            }
+        }
+
         void action_fullscreen () {
             if (is_fullscreen) {
                 unfullscreen ();
@@ -1109,6 +1121,8 @@ namespace PantheonTerminal {
         const GLib.ActionEntry[] main_entries = {
             { "copy", action_copy },
             { "search", action_search },
+            { "search-next", action_search_next },
+            { "search-previous", action_search_previous },
             { "paste", action_paste },
             { "select-all", action_select_all },
             { "open-in-files", action_open_in_files },
@@ -1118,6 +1132,8 @@ namespace PantheonTerminal {
         private void set_main_accelerators () {
             application.set_accels_for_action ("main.copy", {"<Control><Shift>c"});
             application.set_accels_for_action ("main.search", {"<Control><Shift>f"});
+            application.set_accels_for_action ("main.search-next", {"<Control>g", "<Control>Down"});
+            application.set_accels_for_action ("main.search-previous", {"<Control><Shift>g", "<Control>Up"});
             application.set_accels_for_action ("main.paste", {"<Control><Shift>v"});
             application.set_accels_for_action ("main.select-all", {"<Control><Shift>a"});
             application.set_accels_for_action ("main.open-in-files", {"<Control><Shift>e"});

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -310,7 +310,6 @@ namespace PantheonTerminal {
             search_revealer.add (search_toolbar);
 
             enable_main_action ("copy", false);
-            enable_main_action ("open-in-files", true);
 
             notebook = new Granite.Widgets.DynamicNotebook ();
             notebook.tab_added.connect (on_tab_added);
@@ -1118,7 +1117,7 @@ namespace PantheonTerminal {
 
         private void set_main_accelerators () {
             application.set_accels_for_action ("main.copy", {"<Control><Shift>c"});
-            application.set_accels_for_action ("main.search", {"Control><Shift>f"});
+            application.set_accels_for_action ("main.search", {"<Control><Shift>f"});
             application.set_accels_for_action ("main.paste", {"<Control><Shift>v"});
             application.set_accels_for_action ("main.select-all", {"<Control><Shift>a"});
             application.set_accels_for_action ("main.open-in-files", {"<Control><Shift>e"});

--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -28,6 +28,7 @@ namespace PantheonTerminal {
         private Gtk.Revealer search_revealer;
         private Gtk.ToggleButton search_button;
         private Gtk.Button zoom_default_button;
+        private Gtk.MenuButton style_button;
 
         private HashTable<string, TerminalWidget> restorable_terminals;
         private bool is_fullscreen = false;
@@ -290,7 +291,7 @@ namespace PantheonTerminal {
             var style_popover = new Gtk.Popover (null);
             style_popover.add (style_popover_grid);
 
-            var style_button = new Gtk.MenuButton ();
+            style_button = new Gtk.MenuButton ();
             style_button.image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR);
             style_button.popover = style_popover;
             style_button.tooltip_text = _("Style");
@@ -917,6 +918,11 @@ namespace PantheonTerminal {
             }
         }
 
+        void action_open_appmenu () {
+            var open = style_button.get_active ();
+            style_button.set_active (!open);
+        }
+
         void action_close_tab () {
             current_terminal.tab.close ();
             current_terminal.grab_focus ();
@@ -1106,7 +1112,8 @@ namespace PantheonTerminal {
             { "search", action_search },
             { "paste", action_paste },
             { "select-all", action_select_all },
-            { "open-in-files", action_open_in_files }
+            { "open-in-files", action_open_in_files },
+            { "open-appmenu", action_open_appmenu }
         };
 
         private void set_main_accelerators () {
@@ -1115,6 +1122,7 @@ namespace PantheonTerminal {
             application.set_accels_for_action ("main.paste", {"<Control><Shift>v"});
             application.set_accels_for_action ("main.select-all", {"<Control><Shift>a"});
             application.set_accels_for_action ("main.open-in-files", {"<Control><Shift>e"});
+            application.set_accels_for_action ("main.open-appmenu", {"<Super>F10"});
         }
 
         public void enable_main_action (string detailed_action, bool enabled) {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -43,7 +43,7 @@ namespace PantheonTerminal {
             set {
                 this._window = value;
                 this.app = value.app;
-                this.menu = value.ui.get_widget ("ui/AppMenu") as Gtk.Menu;
+                this.menu = value.app_menu;
                 this.menu.show_all ();
             }
         }
@@ -150,12 +150,10 @@ namespace PantheonTerminal {
                     uri = get_link (event);
 
                     if (uri != null) {
-                        window.main_actions.get_action ("Copy").set_sensitive (true);
+                        window.enable_main_action ("copy", true);
                     }
 
-                    menu.select_first (false);
                     menu.popup (null, null, null, event.button, event.time);
-
                     return true;
                 } else if (event.button == Gdk.BUTTON_MIDDLE) {
                     return window.handle_primary_selection_copy_event ();
@@ -181,7 +179,7 @@ namespace PantheonTerminal {
             });
 
             selection_changed.connect (() => {
-                window.main_actions.get_action ("Copy").set_sensitive (get_has_selection ());
+                window.enable_main_action ("copy", get_has_selection ());
             });
 
 


### PR DESCRIPTION
* Replaces deprecated code (GtkActionEntry).
* Add some additional accelerators
* Modify search actions to be more like io.elementary.code

One side-effect of doing it this way is that the popup shows the accelerators.  Although this aids discovery I am not sure whether that is approved design.  If necessary this can be fixed by removing the action accelerators and handling these in the key_press_event closure.