### PR TITLE
Buttons lose focus when finished

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -364,6 +364,10 @@ namespace PantheonTerminal {
             set_titlebar (header);
             add (grid);
 
+            style_popover.closed.connect (() => {
+                current_terminal.grab_focus ();
+            });
+
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;
                 settings.background = SOLARIZED_DARK_BG;

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -61,7 +61,19 @@ namespace PantheonTerminal.Widgets {
             show_all ();
 
             grab_focus.connect (() => {
-                search_entry.grab_focus ();
+                search_entry.grab_focus_without_selecting ();
+            });
+
+            next_button.clicked.connect_after (() => {
+                grab_focus ();
+            });
+
+            previous_button.clicked.connect_after (() => {
+                grab_focus ();
+            });
+
+            cycle_button.clicked.connect_after (() => {
+                grab_focus ();
             });
 
             search_entry.search_changed.connect (() => {


### PR DESCRIPTION
Fixes #241 

Alternative solution which does not prevent focusing of buttons e.g. via keyboard, but loses focus after action completed.