### PR TITLE
Window: Remove centering witchcraft

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -491,9 +491,7 @@ namespace PantheonTerminal {
                 if (x != -1 && y != -1) {
                     move (x, y);
                 } else {
-                    x = (geometry.width - default_width)  / 2;
-                    y = (geometry.height - default_height) / 2;
-                    move (x, y);
+                    window_position = Gtk.WindowPosition.CENTER;
                 }
             }
 


### PR DESCRIPTION
We don't need this in elementary OS because Gala centers windows by default, but this at least removes some unnecessary witchcraft without changing functionality for other DEs