### PR TITLE
Add xmllint to build deps

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,8 @@ Build-Depends: appstream,
                libgtk-3-dev (>= 3.9.10),
                libvte-2.91-dev,
                meson,
-               valac (>= 0.16)
+               valac (>= 0.16),
+               libxml2-utils
 Standards-Version: 4.1.1
 Homepage: https://github.com/elementary/terminal
 


### PR DESCRIPTION
This solves build warnings with gresource that are trying to do xml pre-processing