### PR TITLE
Remove present() calls from new windows

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -49,9 +49,9 @@ public class PantheonTerminal.TerminalApp : Gtk.Application {
         var window = get_last_window ();
 
         if (window == null) {
-            new PantheonTerminalWindow (this).present ();
+            new PantheonTerminalWindow (this);
         } else {
-            new PantheonTerminalWindow (this, false).present ();
+            new PantheonTerminalWindow (this, false);
         }
     }
 


### PR DESCRIPTION
Fixes #281 

`present` is for bringing an already open window to the front, the window manager and the rest of the Gtk stack should be capable of bringing brand new application windows to the front.