### PR TITLE
Reduce headerbar height by disabling subtitle

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -326,6 +326,7 @@ namespace PantheonTerminal {
 
             var header = new Gtk.HeaderBar ();
             header.show_close_button = true;
+            header.has_subtitle = false;
             header.get_style_context ().add_class ("default-decoration");
             header.pack_end (style_button);
             header.pack_end (search_button);


### PR DESCRIPTION
I was struggling with this for a while, finally found the cause today.

Quote from docs (https://developer.gnome.org/gtk3/stable/GtkHeaderBar.html#gtk-header-bar-set-subtitle):
> Note that GtkHeaderBar by default reserves room for the subtitle, even if none is currently set. If this is not desired, set the “has-subtitle” property to FALSE.

Subtitle isn't used anywhere in Terminal, so this shouldn't break anything.