### PR TITLE
Fix zsh process completion notification integration

### DIFF
--- a/data/enable-zsh-completion-notifications
+++ b/data/enable-zsh-completion-notifications
@@ -21,7 +21,7 @@ then
             string:"$(fc -ln -1)" \
             int32:$?
     }
-    precmd_functions=(pantheon_terminal_command_competion_callback)
+    precmd_functions+=(pantheon_terminal_command_competion_callback)
 fi
 
 # Some shells (e.g. BASH) lack the post-execution hook,

--- a/data/enable-zsh-completion-notifications
+++ b/data/enable-zsh-completion-notifications
@@ -18,7 +18,8 @@ then
             /io/elementary/terminal \
             io.elementary.terminal.ProcessFinished \
             string:$PANTHEON_TERMINAL_ID \
-            string:"$(fc -ln -1)"
+            string:"$(fc -ln -1)" \
+            int32:$?
     }
     precmd_functions=(pantheon_terminal_command_competion_callback)
 fi
@@ -41,6 +42,7 @@ then
         /io/elementary/terminal \
         io.elementary.terminal.ProcessFinished \
         string:$PANTHEON_TERMINAL_ID \
-        string:"You should not have seen this, please report the incident to Pantheon Terminal developers."
+        string:"You should not have seen this, please report the incident to Pantheon Terminal developers." \
+        int32:0
 fi
 


### PR DESCRIPTION
The zsh process completion notification script does not work with the latest version of the app due to the exit code not being passed. This PR fixes this issue in the integration script.

For compatibility the integration script now appends the pre-command function to the existing list.

This resolves issue #244 