### PR TITLE
Remove <Control>g and <Control><Shift>g keybindings

### DIFF
--- a/src/PantheonTerminalWindow.vala
+++ b/src/PantheonTerminalWindow.vala
@@ -144,9 +144,7 @@ namespace PantheonTerminal {
             action_accelerators[ACTION_COPY] = "<Control><Shift>c";
             action_accelerators[ACTION_PASTE] = "<Control><Shift>v";
             action_accelerators[ACTION_SEARCH] = "<Control><Shift>f";
-            action_accelerators[ACTION_SEARCH_NEXT] = "<Control>g";
             action_accelerators[ACTION_SEARCH_NEXT] = "<Control>Down";
-            action_accelerators[ACTION_SEARCH_PREVIOUS] = "<Control><Shift>g";
             action_accelerators[ACTION_SEARCH_PREVIOUS] = "<Control>Up";
             action_accelerators[ACTION_SELECT_ALL] = "<Control><Shift>a";
             action_accelerators[ACTION_OPEN_IN_FILES] = "<Control><Shift>e";


### PR DESCRIPTION
`<Control>g` is used in Emacs to cancel out actions. Since `ACTION_SEARCH_NEXT` and `ACTION_SEARCH_PREVIOUS` have other keybindings `<Control>Up` and `<Control>down` the `<Control>g` could be removed without giving up on keybindings.

I'm not entirely sure if removing it is the correct approach. I'm not sure why `<Control>g` was used in the first place but I could add an alternate keybinding if it is necessary.

fixes #306