### PR TITLE
gschema: Make system bell default to true

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -81,7 +81,7 @@
       <description>Defines whether Alt+N goes to nth tab.</description>
     </key>
     <key name="audible-bell" type="b">
-      <default>false</default>
+      <default>true</default>
       <summary>Defines whether the terminal has a bell or not.</summary>
       <description>Enables or disables the terminal bell.</description>
     </key>


### PR DESCRIPTION
Not sure why this is false by default. True would make it consistent with other Gtk.Editables and there is already a setting in System Settings -> Sound to disable the system bell.

Not sure if this should be a setting for Terminal at all, tbh. I dunno why you'd want to disable the bell for only one app