### PR TITLE
Fix search jumping behaviour

### DIFF
--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -83,7 +83,7 @@ namespace PantheonTerminal.Widgets {
 
                 var term = (Vte.Terminal)(window.current_terminal);
                 var search_term = search_entry.text;
-                previous_search ();  /* Ensure that we still at the same highlighted occurrence */
+                previous_search ();  /* Ensure that we still at the highlighted occurrence */
 
                 if (last_search_term_length > search_term.length) {
                     term.match_remove_all ();

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -83,6 +83,8 @@ namespace PantheonTerminal.Widgets {
 
                 var term = (Vte.Terminal)(window.current_terminal);
                 var search_term = search_entry.text;
+                previous_search ();  /* Ensure that we still at the same highlighted occurrence */
+
                 if (last_search_term_length > search_term.length) {
                     term.match_remove_all ();
                     term.unselect_all ();  /* Ensure revised search finds first occurrence first*/


### PR DESCRIPTION
When you use the search, whenever you type a new character it jumps to the next occurrence.
This is the previous behaviour:
![ezgif com-video-to-gif 1](https://user-images.githubusercontent.com/1688821/49326555-be5e3f00-f54b-11e8-824a-1ca038d59ee3.gif)
The new one:
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/1688821/49326516-25c7bf00-f54b-11e8-8336-3b2b311c64a6.gif)
