### PR TITLE
meson: add missing 'gee-0.8' dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ executable(
     'src/Widgets/TerminalWidget.vala',
     terminal_resources,
     dependencies: [
+        dependency('gee-0.8'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
         dependency('gtk+-3.0'),


### PR DESCRIPTION
This is necessary because terminal uses Gee directly, and granite built with
meson is more conservative with the linker flags it includes.

See: src/MainWindow.vala#L75