### PR TITLE
Fix response code being wrong in another place

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -922,7 +922,7 @@ namespace PantheonTerminal {
                 t = (TerminalWidget) t;
                 if (t.has_foreground_process ()) {
                     var d = new ForegroundProcessDialog.before_close (this);
-                    if (d.run () == 1) {
+                    if (d.run () == Gtk.ResponseType.ACCEPT) {
                         t.kill_fg ();
                         d.destroy ();
                     } else {


### PR DESCRIPTION
Fixes #367.

Caused by https://github.com/elementary/terminal/commit/618cf0509b93fe5bdca4ac0c1cbf4eb68b1199ff. Changed the response code for closing individual tabs but didn't change the response code for closing the terminal window.