### PR TITLE
Use Black 500 from the official palette for the Dark colorscheme option

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -47,7 +47,7 @@
 }
 
 .color-dark radio {
-    background: #252E32;
+    background: #333333;
     border-color: #151B1C;
     color: #fff;
 }

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -109,7 +109,7 @@
       </description>
     </key>
     <key name="background" type="s">
-      <default>"rgba(37, 46, 50, 0.95)"</default>
+      <default>"rgba(33, 33, 33, 0.95)"</default>
       <summary>Color of the background.</summary>
       <description>
           The color of the background of the terminal.

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -35,7 +35,7 @@ namespace PantheonTerminal {
 
         private const string HIGH_CONTRAST_BG = "#fff";
         private const string HIGH_CONTRAST_FG = "#333";
-        private const string SOLARIZED_DARK_BG = "rgba(37, 46, 50, 0.95)";
+        private const string SOLARIZED_DARK_BG = "rgba(33, 33, 33, 0.95)";
         private const string SOLARIZED_DARK_FG = "#94a3a5";
         private const string SOLARIZED_LIGHT_BG = "rgba(253, 246, 227, 0.95)";
         private const string SOLARIZED_LIGHT_FG = "#586e75";


### PR DESCRIPTION
Requires elementary/stylesheet#510 to be merged first!

This changes the untracked blue-ish black color (Which isn't even the Solarized Dark background color) to Black 500 from the palette for Dark colorscheme cohesion.

Screenshot:
![Screenshot from 2019-05-26 00 53 43](https://user-images.githubusercontent.com/4886639/58377172-da69f880-7f50-11e9-8a4f-87eb84c44ca5.png)