### PR TITLE
MainWindow: Add a separator to right click menu

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -215,6 +215,7 @@ namespace PantheonTerminal {
             menu.append (copy_last_output_menuitem);
             menu.append (paste_menuitem);
             menu.append (select_all_menuitem);
+            menu.append (new Gtk.SeparatorMenuItem ());
             menu.append (search_menuitem);
             menu.append (show_in_file_browser_menuitem);
             menu.insert_action_group ("win", actions);


### PR DESCRIPTION
This really helps once the menu is a little more busy with accel labels. I drew the separator here because these actions are all about manipulating text until we get to find and open files. I guess Find could arguably be about manipulating text, so I wouldn't argue to strongly if others felt it was better just separating the last item

![Screenshot from 2019-07-09 09 08 06@2x](https://user-images.githubusercontent.com/7277719/60905104-3a7adc80-a229-11e9-85aa-7a234a632687.png)
