### PR TITLE
Use palette colors for default bg/fg

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -47,8 +47,8 @@
 }
 
 .color-dark radio {
-    background: #252E32;
-    border-color: #151B1C;
+    background: mix(@BLACK_500, @BLACK_300, 0.5);
+    border-color: @BLACK_700;
     color: #fff;
 }
 

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -91,7 +91,7 @@
     </key>
 
     <key name="foreground" type="s">
-      <default>"#94a3a5"</default>
+      <default>"#d4d4d4"</default>
       <summary>Color of the text.</summary>
       <description>
           The color of the text of the terminal.
@@ -103,7 +103,7 @@
       </description>
     </key>
     <key name="background" type="s">
-      <default>"rgba(37, 46, 50, 0.95)"</default>
+      <default>"rgba(51, 51, 51, 0.95)"</default>
       <summary>Color of the background.</summary>
       <description>
           The color of the background of the terminal.

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -38,8 +38,8 @@ namespace PantheonTerminal {
 
         private const string HIGH_CONTRAST_BG = "#fff";
         private const string HIGH_CONTRAST_FG = "#333";
-        private const string SOLARIZED_DARK_BG = "rgba(37, 46, 50, 0.95)";
-        private const string SOLARIZED_DARK_FG = "#94a3a5";
+        private const string DARK_BG = "rgba(51, 51, 51, 0.95)";
+        private const string DARK_FG = "#d5d5d5";
         private const string SOLARIZED_LIGHT_BG = "rgba(253, 246, 227, 0.95)";
         private const string SOLARIZED_LIGHT_FG = "#586e75";
 
@@ -327,7 +327,7 @@ namespace PantheonTerminal {
 
             var color_button_dark = new Gtk.RadioButton.from_widget (color_button_white);
             color_button_dark.halign = Gtk.Align.CENTER;
-            color_button_dark.tooltip_text = _("Solarized Dark");
+            color_button_dark.tooltip_text = _("Dark");
 
             var color_button_dark_context = color_button_dark.get_style_context ();
             color_button_dark_context.add_class ("color-button");
@@ -408,15 +408,15 @@ namespace PantheonTerminal {
                 case SOLARIZED_LIGHT_BG:
                     color_button_light.active = true;
                     break;
-                case SOLARIZED_DARK_BG:
+                case DARK_BG:
                     color_button_dark.active = true;
                     break;
             }
 
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;
-                settings.background = SOLARIZED_DARK_BG;
-                settings.foreground = SOLARIZED_DARK_FG;
+                settings.background = DARK_BG;
+                settings.foreground = DARK_FG;
             });
 
             color_button_light.clicked.connect (() => {


### PR DESCRIPTION
Better matches https://github.com/elementary/stylesheet/pull/510, plus better contrast.

## Before

![image](https://user-images.githubusercontent.com/611168/61832293-e9c0d180-ae2d-11e9-9d4b-ab656e4c9d30.png)

![image](https://user-images.githubusercontent.com/611168/61832341-0bba5400-ae2e-11e9-9d87-7453b21b0532.png)

## After

![image](https://user-images.githubusercontent.com/611168/61832275-dada1f00-ae2d-11e9-8bfd-b403551b5900.png)

![image](https://user-images.githubusercontent.com/611168/61832236-b5e5ac00-ae2d-11e9-9b82-80e7abbf279b.png)
 
Fixes #373