### PR TITLE
Use Solarized Dark for dark UI

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -47,8 +47,8 @@
 }
 
 .color-dark radio {
-    background: #252E32;
-    border-color: #151B1C;
+    background: #002b36; /* Solarized Dark Base03 */
+    border-color: #000;
     color: #fff;
 }
 

--- a/data/dark.css
+++ b/data/dark.css
@@ -1,0 +1,20 @@
+/*
+* Copyright (c) 2019 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 3, as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+@define-color base_color #073642;
+

--- a/data/io.elementary.terminal.gresource.xml
+++ b/data/io.elementary.terminal.gresource.xml
@@ -2,5 +2,6 @@
 <gresources>
   <gresource prefix="/io/elementary/terminal">
     <file alias="Application.css" compressed="true">Application.css</file>
+    <file alias="dark.css" compressed="true">dark.css</file>
   </gresource>
 </gresources>

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -91,7 +91,8 @@
     </key>
 
     <key name="foreground" type="s">
-      <default>"#94a3a5"</default>
+      <!-- Solarized Dark Base1 (#93a1a1) with the Value increased to be WCAG AAA contrast-compliant (7:1) -->
+      <default>"#a5B5B5"</default>
       <summary>Color of the text.</summary>
       <description>
           The color of the text of the terminal.
@@ -103,7 +104,8 @@
       </description>
     </key>
     <key name="background" type="s">
-      <default>"rgba(37, 46, 50, 0.95)"</default>
+      <!-- Solarized Dark Base03 with 95% opacity -->
+      <default>"rgba(0, 43, 54, 0.95)"</default>
       <summary>Color of the background.</summary>
       <description>
           The color of the background of the terminal.
@@ -115,6 +117,7 @@
       </description>
     </key>
     <key name="cursor-color" type="s">
+      <!-- Solarized Dark Base0 -->
       <default>"#839496"</default>
       <summary>Color of the cursor.</summary>
       <description>


### PR DESCRIPTION
As an alternative to #390 if we wanted Terminal to be more explicitly Solarized Dark, like the Code syntax highlighting. Going for something like this:

![image (7)](https://user-images.githubusercontent.com/611168/62013387-21da5400-b14f-11e9-896e-440278ca5a16.png)

For some reason loading the stylesheet isn't working yet.