### PR TITLE
Remove unnecessary handling of middle-click.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -566,18 +566,6 @@ namespace Terminal {
             return false;
         }
 
-        public bool handle_primary_selection_copy_event () {
-            if (search_toolbar.search_entry.has_focus) {
-                return false;
-            } else if (current_terminal.get_has_selection ()) {
-                current_terminal.copy_primary ();
-                primary_selection.request_text (on_get_text);
-                return true;
-            }
-
-            return false;
-        }
-
         private void restore_saved_state (bool restore_pos = true) {
             if (Granite.Services.System.history_is_enabled () &&
                 settings.remember_tabs) {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -140,8 +140,6 @@ namespace Terminal {
                     menu.popup_at_pointer (event);
 
                     return true;
-                } else if (event.button == Gdk.BUTTON_MIDDLE) {
-                    return window.handle_primary_selection_copy_event ();
                 }
 
                 return false;


### PR DESCRIPTION
There seems to be no reason for terminal to handle middle-click if it is intended that the mouse-touchpad setting plug should be honored.

After removing this code, middle-click will paste the current selection (either inside Terminal or in another app eg.g Code) only if the mouse-touchpad setting "Middle Click Paste" is `true`.  This then matches the behaviour of Code.

Note that this depends on xsettings override being supported which is true for elementary but may not be true for another OS.  If this is a problem, it may be desirable to fallback to middle-click-paste?