### PR TITLE
Add solarized black theme

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -46,6 +46,12 @@
         0 0 0 1px alpha (@colorAccent, 0.25);
 }
 
+.color-black radio {
+    background: #1a1a1a;
+    border-color: #151B1C;
+    color: #fff;
+}
+
 .color-dark radio {
     background: #252E32;
     border-color: #151B1C;

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -91,7 +91,7 @@
     </key>
 
     <key name="foreground" type="s">
-      <default>"#94a3a5"</default>
+      <default>"#d4d4d4"</default>
       <summary>Color of the text.</summary>
       <description>
           The color of the text of the terminal.
@@ -103,7 +103,7 @@
       </description>
     </key>
     <key name="background" type="s">
-      <default>"rgba(37, 46, 50, 0.95)"</default>
+      <default>"rgba(51, 51, 51, 0.95)"</default>
       <summary>Color of the background.</summary>
       <description>
           The color of the background of the terminal.

--- a/po/ar.po
+++ b/po/ar.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-03-13 16:27+0000\n"
+"PO-Revision-Date: 2019-08-26 04:22+0000\n"
 "Last-Translator: nasserbinlaboun <nasser1990com@gmail.com>\n"
 "Language-Team: Arabic <https://l10n.elementary.io/projects/terminal/terminal/"
 "ar/>\n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 "
 "&& n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
-"X-Generator: Weblate 3.4\n"
+"X-Generator: Weblate 3.7.1\n"
 "X-Launchpad-Export-Date: 2016-10-17 06:41+0000\n"
 
 #: src/Application.vala:109
@@ -62,7 +62,6 @@ msgid "Show in File Browser"
 msgstr "أظهر في متصفح الملفات"
 
 #: src/MainWindow.vala:283
-#, fuzzy
 msgid "Zoom out"
 msgstr "تصغير"
 
@@ -71,17 +70,16 @@ msgid "Default zoom level"
 msgstr "مستوى التقريب المبدئي"
 
 #: src/MainWindow.vala:297
-#, fuzzy
 msgid "Zoom in"
 msgstr "تكبير"
 
 #: src/MainWindow.vala:310
 msgid "High Contrast"
-msgstr ""
+msgstr "تباين عالي"
 
 #: src/MainWindow.vala:318
 msgid "Solarized Light"
-msgstr ""
+msgstr "ضوء شمسي"
 
 #: src/MainWindow.vala:326
 msgid "Solarized Dark"
@@ -93,11 +91,11 @@ msgstr ""
 
 #: src/MainWindow.vala:1089
 msgid "Hide find bar"
-msgstr ""
+msgstr "اخفاء شريط البحث"
 
 #: src/Dialogs/ForegroundProcessDialog.vala:26
 msgid "Are you sure you want to close this tab?"
-msgstr "هل أنت متأكد من أنك تريد اغلاق هذا اللسان؟"
+msgstr "هل أنت متأكد من أنك تريد اغلاق هذا التبويب؟"
 
 #: src/Dialogs/ForegroundProcessDialog.vala:28
 msgid "There is an active process on this tab."
@@ -125,7 +123,7 @@ msgstr ""
 
 #: src/Dialogs/ForegroundProcessDialog.vala:43
 msgid "Quit Terminal"
-msgstr ""
+msgstr "اغلاق الطرفية"
 
 #: src/Dialogs/UnsafePasteDialog.vala:29
 msgid "This command is asking for Administrative access to your computer"
@@ -133,35 +131,35 @@ msgstr ""
 
 #: src/Dialogs/UnsafePasteDialog.vala:32
 msgid "Copying commands into the Terminal can be dangerous."
-msgstr ""
+msgstr "نسخ الأوامر إلى الطرفية يمكن أن يكون خطيرًا."
 
 #: src/Dialogs/UnsafePasteDialog.vala:33
 msgid "Be sure you understand what each part of this command does."
-msgstr ""
+msgstr "تأكد من أنك تفهم ما يفعله كل جزء من هذا الأمر."
 
 #: src/Dialogs/UnsafePasteDialog.vala:35
 msgid "Show paste protection warnings"
-msgstr ""
+msgstr "إظهار تحذيرات حماية اللصق"
 
 #: src/Dialogs/UnsafePasteDialog.vala:40
 msgid "Don't Paste"
-msgstr ""
+msgstr "لا تلصق"
 
 #: src/Dialogs/UnsafePasteDialog.vala:42
 msgid "Paste Anyway"
-msgstr ""
+msgstr "الصق على أي حال"
 
 #: src/Widgets/SearchToolbar.vala:36
 msgid "Find"
-msgstr ""
+msgstr "ابحث"
 
 #: src/Widgets/SearchToolbar.vala:42
 msgid "Previous result"
-msgstr ""
+msgstr "النتيجة السابقة"
 
 #: src/Widgets/SearchToolbar.vala:49
 msgid "Next result"
-msgstr ""
+msgstr "النتيجة التالية"
 
 #: src/Widgets/SearchToolbar.vala:56
 msgid "Cyclic search"

--- a/po/extra/en_GB.po
+++ b/po/extra/en_GB.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2018-04-29 14:48+0000\n"
-"Last-Translator: Ciaran Ainsworth <cda@whistlingkappa.com>\n"
-"Language-Team: English (United Kingdom) <https://weblate.elementary.io/"
-"projects/terminal/extra/en_GB/>\n"
+"PO-Revision-Date: 2019-08-22 11:22+0000\n"
+"Last-Translator: Ciarán Ainsworth <ciaranainsworth@posteo.net>\n"
+"Language-Team: English (United Kingdom) <https://l10n.elementary.io/projects/"
+"terminal/extra/en_GB/>\n"
 "Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n != 1;\n"
-"X-Generator: Weblate 2.18\n"
+"X-Generator: Weblate 3.7.1\n"
 "X-Launchpad-Export-Date: 2016-10-17 06:41+0000\n"
 
 #: data/io.elementary.terminal.appdata.xml.in:8
@@ -41,11 +41,11 @@ msgstr ""
 
 #: data/io.elementary.terminal.appdata.xml.in:41
 msgid "Support Ctrl+Equal key combo to zoom in"
-msgstr ""
+msgstr "Support Ctrl+Equal key combo to zoom in"
 
 #: data/io.elementary.terminal.appdata.xml.in:42
 msgid "Fix a wrong foreground process response code"
-msgstr ""
+msgstr "Fix a wrong foreground process response code"
 
 #: data/io.elementary.terminal.appdata.xml.in:43
 #: data/io.elementary.terminal.appdata.xml.in:53
@@ -62,51 +62,51 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:153
 #: data/io.elementary.terminal.appdata.xml.in:168
 msgid "Translation updates"
-msgstr ""
+msgstr "Translation updates"
 
 #: data/io.elementary.terminal.appdata.xml.in:50
 msgid "Return focus after popover menu closes"
-msgstr ""
+msgstr "Return focus after popover menu closes"
 
 #: data/io.elementary.terminal.appdata.xml.in:51
 msgid "Prevent search and style buttons from receiving focus"
-msgstr ""
+msgstr "Prevent search and style buttons from receiving focus"
 
 #: data/io.elementary.terminal.appdata.xml.in:52
 msgid "Hide the cursor while typing"
-msgstr ""
+msgstr "Hide the cursor while typing"
 
 #: data/io.elementary.terminal.appdata.xml.in:60
 msgid "Fix erratic search text highlightning behavior"
-msgstr ""
+msgstr "Fix erratic search text highlightning behaviour"
 
 #: data/io.elementary.terminal.appdata.xml.in:61
 msgid "Support -h flag for help"
-msgstr ""
+msgstr "Support -h flag for help"
 
 #: data/io.elementary.terminal.appdata.xml.in:62
 msgid "Disable audible bell"
-msgstr ""
+msgstr "Disable audible bell"
 
 #: data/io.elementary.terminal.appdata.xml.in:63
 msgid "Add Alt+↑ action to scroll to last command"
-msgstr ""
+msgstr "Add Alt+↑ action to scroll to last command"
 
 #: data/io.elementary.terminal.appdata.xml.in:64
 msgid "Add Alt+c action to copy last output"
-msgstr ""
+msgstr "Add Alt+c action to copy last output"
 
 #: data/io.elementary.terminal.appdata.xml.in:65
 msgid "Add accels to tooltips"
-msgstr ""
+msgstr "Add accels to tooltips"
 
 #: data/io.elementary.terminal.appdata.xml.in:73
 msgid "Fix zsh notifications"
-msgstr ""
+msgstr "Fix zsh notifications"
 
 #: data/io.elementary.terminal.appdata.xml.in:74
 msgid "Conditional ctrl+g shortcut to deconflict with emacs"
-msgstr ""
+msgstr "Conditional ctrl+g shortcut to deconflict with emacs"
 
 #: data/io.elementary.terminal.appdata.xml.in:75
 #: data/io.elementary.terminal.appdata.xml.in:83
@@ -120,31 +120,31 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:152
 #: data/io.elementary.terminal.appdata.xml.in:167
 msgid "Minor bug fixes"
-msgstr ""
+msgstr "Minor bug fixes"
 
 #: data/io.elementary.terminal.appdata.xml.in:115
 msgid "FISH integration fixes"
-msgstr ""
+msgstr "FISH integration fixes"
 
 #: data/io.elementary.terminal.appdata.xml.in:116
 msgid "Theme preference menu"
-msgstr ""
+msgstr "Theme preference menu"
 
 #: data/io.elementary.terminal.appdata.xml.in:117
 msgid "Zoom level controls"
-msgstr ""
+msgstr "Zoom level controls"
 
 #: data/io.elementary.terminal.appdata.xml.in:134
 msgid "Allow tab to close after typing exit at the commandline"
-msgstr ""
+msgstr "Allow tab to close after typing exit at the commandline"
 
 #: data/io.elementary.terminal.appdata.xml.in:143
 msgid "Fix copying URLs to clipboard"
-msgstr ""
+msgstr "Fix copying URLs to clipboard"
 
 #: data/io.elementary.terminal.appdata.xml.in:160
 msgid "Fix appstream date format"
-msgstr ""
+msgstr "Fix appstream date format"
 
 #: data/io.elementary.terminal.appdata.xml.in:202
 msgid "elementary LLC."

--- a/po/extra/fr.po
+++ b/po/extra/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-07-24 21:25+0000\n"
+"PO-Revision-Date: 2019-08-20 11:22+0000\n"
 "Last-Translator: Nathan <bonnemainsnathan@gmail.com>\n"
 "Language-Team: French <https://l10n.elementary.io/projects/terminal/extra/fr/"
 ">\n"
@@ -88,7 +88,7 @@ msgstr "Prise en charge du paramètre -h pour obtenir de l'aide"
 
 #: data/io.elementary.terminal.appdata.xml.in:62
 msgid "Disable audible bell"
-msgstr ""
+msgstr "Désactivation du son de cloche"
 
 #: data/io.elementary.terminal.appdata.xml.in:63
 msgid "Add Alt+↑ action to scroll to last command"

--- a/po/extra/mr.po
+++ b/po/extra/mr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: extra\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-07-22 02:24+0000\n"
+"PO-Revision-Date: 2019-09-08 19:22+0000\n"
 "Last-Translator: Prachi Joshi <josprachi@yahoo.com>\n"
 "Language-Team: Marathi <https://l10n.elementary.io/projects/terminal/extra/"
 "mr/>\n"
@@ -101,11 +101,11 @@ msgstr "टूलटिप्समध्ये अॅक्सल जोडा"
 
 #: data/io.elementary.terminal.appdata.xml.in:73
 msgid "Fix zsh notifications"
-msgstr ""
+msgstr "zsh सूचना निराकरण करा"
 
 #: data/io.elementary.terminal.appdata.xml.in:74
 msgid "Conditional ctrl+g shortcut to deconflict with emacs"
-msgstr ""
+msgstr "सशर्त ctrl + g शॉर्टकट इमॅक्सला डीकॉन्फ्लिक्ट करण्यासाठी"
 
 #: data/io.elementary.terminal.appdata.xml.in:75
 #: data/io.elementary.terminal.appdata.xml.in:83
@@ -119,31 +119,31 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:152
 #: data/io.elementary.terminal.appdata.xml.in:167
 msgid "Minor bug fixes"
-msgstr ""
+msgstr "किरकोळ दोष निराकरणे"
 
 #: data/io.elementary.terminal.appdata.xml.in:115
 msgid "FISH integration fixes"
-msgstr ""
+msgstr "FISH एकत्रीकरण निराकरणे"
 
 #: data/io.elementary.terminal.appdata.xml.in:116
 msgid "Theme preference menu"
-msgstr ""
+msgstr "थीम प्राधान्य मेनू"
 
 #: data/io.elementary.terminal.appdata.xml.in:117
 msgid "Zoom level controls"
-msgstr ""
+msgstr "झूम पातळी नियंत्रणे"
 
 #: data/io.elementary.terminal.appdata.xml.in:134
 msgid "Allow tab to close after typing exit at the commandline"
-msgstr ""
+msgstr "कमांडलाइनवर एग्जिट टाइप केल्यावर टॅब बंद करण्यास परवानगी द्या"
 
 #: data/io.elementary.terminal.appdata.xml.in:143
 msgid "Fix copying URLs to clipboard"
-msgstr ""
+msgstr "क्लिपबोर्डवर URL कॉपी करणे निश्चित करा"
 
 #: data/io.elementary.terminal.appdata.xml.in:160
 msgid "Fix appstream date format"
-msgstr ""
+msgstr "अ‍ॅपस्ट्रीम तारीख स्वरूप निश्चित करा"
 
 #: data/io.elementary.terminal.appdata.xml.in:202
 msgid "elementary LLC."

--- a/po/extra/pt.po
+++ b/po/extra/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-07-27 22:58+0000\n"
+"PO-Revision-Date: 2019-08-22 11:22+0000\n"
 "Last-Translator: Hugo Carvalho <hugokarvalho@hotmail.com>\n"
 "Language-Team: Portuguese <https://l10n.elementary.io/projects/terminal/"
 "extra/pt/>\n"
@@ -66,47 +66,47 @@ msgstr "Atualizações de tradução"
 
 #: data/io.elementary.terminal.appdata.xml.in:50
 msgid "Return focus after popover menu closes"
-msgstr ""
+msgstr "Retornar o foco após o menu popover fechar"
 
 #: data/io.elementary.terminal.appdata.xml.in:51
 msgid "Prevent search and style buttons from receiving focus"
-msgstr ""
+msgstr "Impedir que os botões de pesquisa e estilo recebam o foco"
 
 #: data/io.elementary.terminal.appdata.xml.in:52
 msgid "Hide the cursor while typing"
-msgstr ""
+msgstr "Oculta o cursor enquanto escreve"
 
 #: data/io.elementary.terminal.appdata.xml.in:60
 msgid "Fix erratic search text highlightning behavior"
-msgstr ""
+msgstr "Corrigir comportamento errático de realce de texto de pesquisa"
 
 #: data/io.elementary.terminal.appdata.xml.in:61
 msgid "Support -h flag for help"
-msgstr ""
+msgstr "Suporta o sinalizador -h para a ajuda"
 
 #: data/io.elementary.terminal.appdata.xml.in:62
 msgid "Disable audible bell"
-msgstr ""
+msgstr "Desativar campainha audível"
 
 #: data/io.elementary.terminal.appdata.xml.in:63
 msgid "Add Alt+↑ action to scroll to last command"
-msgstr ""
+msgstr "Adiciona a ação Alt+↑ para rolar para o último comando"
 
 #: data/io.elementary.terminal.appdata.xml.in:64
 msgid "Add Alt+c action to copy last output"
-msgstr ""
+msgstr "Adicionar ação Alt+c para copiar a última saída"
 
 #: data/io.elementary.terminal.appdata.xml.in:65
 msgid "Add accels to tooltips"
-msgstr ""
+msgstr "Adicionar níveis às dicas de ferramentas"
 
 #: data/io.elementary.terminal.appdata.xml.in:73
 msgid "Fix zsh notifications"
-msgstr ""
+msgstr "Corrigir notificações zsh"
 
 #: data/io.elementary.terminal.appdata.xml.in:74
 msgid "Conditional ctrl+g shortcut to deconflict with emacs"
-msgstr ""
+msgstr "Atalho ctrl+g condicional para descongestionar com o emacs"
 
 #: data/io.elementary.terminal.appdata.xml.in:75
 #: data/io.elementary.terminal.appdata.xml.in:83
@@ -120,31 +120,31 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:152
 #: data/io.elementary.terminal.appdata.xml.in:167
 msgid "Minor bug fixes"
-msgstr ""
+msgstr "Pequenas correções de erros"
 
 #: data/io.elementary.terminal.appdata.xml.in:115
 msgid "FISH integration fixes"
-msgstr ""
+msgstr "Correções de integração FISH"
 
 #: data/io.elementary.terminal.appdata.xml.in:116
 msgid "Theme preference menu"
-msgstr ""
+msgstr "Menu de preferências de tema"
 
 #: data/io.elementary.terminal.appdata.xml.in:117
 msgid "Zoom level controls"
-msgstr ""
+msgstr "Controlos de nível de zoom"
 
 #: data/io.elementary.terminal.appdata.xml.in:134
 msgid "Allow tab to close after typing exit at the commandline"
-msgstr ""
+msgstr "Permitir que o separador feche após escrever exit na linha de comando"
 
 #: data/io.elementary.terminal.appdata.xml.in:143
 msgid "Fix copying URLs to clipboard"
-msgstr ""
+msgstr "Corrigir a cópia de URLs para a área de transferência"
 
 #: data/io.elementary.terminal.appdata.xml.in:160
 msgid "Fix appstream date format"
-msgstr ""
+msgstr "Corrigir formato de data do appstream"
 
 #: data/io.elementary.terminal.appdata.xml.in:202
 msgid "elementary LLC."

--- a/po/extra/pt_BR.po
+++ b/po/extra/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2019-08-15 18:22+0000\n"
+"PO-Revision-Date: 2019-08-20 11:22+0000\n"
 "Last-Translator: Rodrigo Oliveira <rod.oliveira@gmail.com>\n"
 "Language-Team: Portuguese (Brazil) <https://l10n.elementary.io/projects/"
 "terminal/extra/pt_BR/>\n"
@@ -46,7 +46,7 @@ msgstr "Suporta a combinação das teclas Ctrl+Equal para aumentar o zoom"
 
 #: data/io.elementary.terminal.appdata.xml.in:42
 msgid "Fix a wrong foreground process response code"
-msgstr ""
+msgstr "Corrigir um código de resposta incorreto do processo de primeiro plano"
 
 #: data/io.elementary.terminal.appdata.xml.in:43
 #: data/io.elementary.terminal.appdata.xml.in:53
@@ -63,51 +63,51 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:153
 #: data/io.elementary.terminal.appdata.xml.in:168
 msgid "Translation updates"
-msgstr ""
+msgstr "Atualizações de tradução"
 
 #: data/io.elementary.terminal.appdata.xml.in:50
 msgid "Return focus after popover menu closes"
-msgstr ""
+msgstr "Retornar o foco após o menu popover fechar"
 
 #: data/io.elementary.terminal.appdata.xml.in:51
 msgid "Prevent search and style buttons from receiving focus"
-msgstr ""
+msgstr "Impedir que os botões de pesquisa e estilo recebam o foco"
 
 #: data/io.elementary.terminal.appdata.xml.in:52
 msgid "Hide the cursor while typing"
-msgstr ""
+msgstr "Esconda o cursor enquanto digita"
 
 #: data/io.elementary.terminal.appdata.xml.in:60
 msgid "Fix erratic search text highlightning behavior"
-msgstr ""
+msgstr "Corrigir comportamento errático de realce de texto de pesquisa"
 
 #: data/io.elementary.terminal.appdata.xml.in:61
 msgid "Support -h flag for help"
-msgstr ""
+msgstr "Suportar sinalizador -h para ajuda"
 
 #: data/io.elementary.terminal.appdata.xml.in:62
 msgid "Disable audible bell"
-msgstr ""
+msgstr "Desativar campainha audível"
 
 #: data/io.elementary.terminal.appdata.xml.in:63
 msgid "Add Alt+↑ action to scroll to last command"
-msgstr ""
+msgstr "Adicione a ação Alt+↑ para rolar para o último comando"
 
 #: data/io.elementary.terminal.appdata.xml.in:64
 msgid "Add Alt+c action to copy last output"
-msgstr ""
+msgstr "Adicionar ação Alt+c para copiar a última saída"
 
 #: data/io.elementary.terminal.appdata.xml.in:65
 msgid "Add accels to tooltips"
-msgstr ""
+msgstr "Adicionar níveis às dicas de ferramentas"
 
 #: data/io.elementary.terminal.appdata.xml.in:73
 msgid "Fix zsh notifications"
-msgstr ""
+msgstr "Corrigir notificações zsh"
 
 #: data/io.elementary.terminal.appdata.xml.in:74
 msgid "Conditional ctrl+g shortcut to deconflict with emacs"
-msgstr ""
+msgstr "Atalho Ctrl+g condicional para não conflitar com o emacs"
 
 #: data/io.elementary.terminal.appdata.xml.in:75
 #: data/io.elementary.terminal.appdata.xml.in:83
@@ -121,31 +121,32 @@ msgstr ""
 #: data/io.elementary.terminal.appdata.xml.in:152
 #: data/io.elementary.terminal.appdata.xml.in:167
 msgid "Minor bug fixes"
-msgstr ""
+msgstr "Pequenas correções de bugs"
 
 #: data/io.elementary.terminal.appdata.xml.in:115
 msgid "FISH integration fixes"
-msgstr ""
+msgstr "Correções de integração FISH"
 
 #: data/io.elementary.terminal.appdata.xml.in:116
 msgid "Theme preference menu"
-msgstr ""
+msgstr "Menu de preferências de tema"
 
 #: data/io.elementary.terminal.appdata.xml.in:117
 msgid "Zoom level controls"
-msgstr ""
+msgstr "Controles de nível de zoom"
 
 #: data/io.elementary.terminal.appdata.xml.in:134
 msgid "Allow tab to close after typing exit at the commandline"
 msgstr ""
+"Permitir que a guia seja fechada após a digitar exit na linha de comando"
 
 #: data/io.elementary.terminal.appdata.xml.in:143
 msgid "Fix copying URLs to clipboard"
-msgstr ""
+msgstr "Corrigir a cópia de URLs para a área de transferência"
 
 #: data/io.elementary.terminal.appdata.xml.in:160
 msgid "Fix appstream date format"
-msgstr ""
+msgstr "Corrigir formato de data do appstream"
 
 #: data/io.elementary.terminal.appdata.xml.in:202
 msgid "elementary LLC."

--- a/po/extra/pt_BR.po
+++ b/po/extra/pt_BR.po
@@ -8,16 +8,16 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2019-06-26 22:46+0200\n"
-"PO-Revision-Date: 2018-08-30 00:03+0000\n"
+"PO-Revision-Date: 2019-08-15 18:22+0000\n"
 "Last-Translator: Rodrigo Oliveira <rod.oliveira@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://weblate.elementary.io/projects/"
+"Language-Team: Portuguese (Brazil) <https://l10n.elementary.io/projects/"
 "terminal/extra/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.0.1\n"
+"X-Generator: Weblate 3.7.1\n"
 "X-Launchpad-Export-Date: 2016-10-17 06:41+0000\n"
 
 #: data/io.elementary.terminal.appdata.xml.in:8
@@ -42,7 +42,7 @@ msgstr ""
 
 #: data/io.elementary.terminal.appdata.xml.in:41
 msgid "Support Ctrl+Equal key combo to zoom in"
-msgstr ""
+msgstr "Suporta a combinação das teclas Ctrl+Equal para aumentar o zoom"
 
 #: data/io.elementary.terminal.appdata.xml.in:42
 msgid "Fix a wrong foreground process response code"

--- a/po/tr.po
+++ b/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: pantheon-terminal\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2018-12-10 09:15-0800\n"
-"PO-Revision-Date: 2019-06-06 19:30+0000\n"
+"PO-Revision-Date: 2019-08-22 11:22+0000\n"
 "Last-Translator: Ozgur Baskin <bebeto_baskin@yahoo.com>\n"
 "Language-Team: Turkish <https://l10n.elementary.io/projects/terminal/"
 "terminal/tr/>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
-"X-Generator: Weblate 3.6.1\n"
+"X-Generator: Weblate 3.7.1\n"
 "X-Launchpad-Export-Date: 2016-10-17 06:41+0000\n"
 
 #: src/Application.vala:109
@@ -74,7 +74,7 @@ msgstr "Yakınlaştır"
 
 #: src/MainWindow.vala:310
 msgid "High Contrast"
-msgstr "Yüksek Kontrast"
+msgstr "Yüksek Karşıtlık"
 
 #: src/MainWindow.vala:318
 msgid "Solarized Light"

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class PantheonTerminal.TerminalApp : Gtk.Application {
+public class Terminal.Application : Gtk.Application {
     public static GLib.Settings saved_state;
 
     private GLib.List <MainWindow> windows;
@@ -44,7 +44,7 @@ public class PantheonTerminal.TerminalApp : Gtk.Application {
         Intl.setlocale (LocaleCategory.ALL, "");
     }
 
-    public TerminalApp () {
+    public Application () {
         Granite.Services.Logger.initialize ("PantheonTerminal");
         Granite.Services.Logger.DisplayLevel = Granite.Services.LogLevel.DEBUG;
 
@@ -216,7 +216,7 @@ public class PantheonTerminal.TerminalApp : Gtk.Application {
     };
 
     public static int main (string[] args) {
-        var app = new TerminalApp ();
+        var app = new Terminal.Application ();
         return app.run (args);
     }
 }

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace PantheonTerminal {
+namespace Terminal {
     [DBus (name="io.elementary.terminal")]
     public class DBus {
         [DBus (visible = false)]

--- a/src/Dialogs/ForegroundProcessDialog.vala
+++ b/src/Dialogs/ForegroundProcessDialog.vala
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class PantheonTerminal.ForegroundProcessDialog : Granite.MessageDialog {
+public class Terminal.ForegroundProcessDialog : Granite.MessageDialog {
     public string button_label { get; construct; }
 
     public ForegroundProcessDialog (MainWindow parent) {

--- a/src/Dialogs/UnsafePasteDialog.vala
+++ b/src/Dialogs/UnsafePasteDialog.vala
@@ -16,7 +16,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class PantheonTerminal.UnsafePasteDialog : Granite.MessageDialog {
+public class Terminal.UnsafePasteDialog : Granite.MessageDialog {
     public UnsafePasteDialog (MainWindow parent) {
         Object (
             buttons: Gtk.ButtonsType.NONE,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -350,14 +350,14 @@ namespace Terminal {
 
             var style_popover_grid = new Gtk.Grid ();
             style_popover_grid.margin = 12;
-            style_popover_grid.column_spacing = 8;  //6
+            style_popover_grid.column_spacing = 6;
             style_popover_grid.row_spacing = 12;
             style_popover_grid.width_request = 200;
-            style_popover_grid.attach (font_size_grid, 0, 0, 3, 1);
+            style_popover_grid.attach (font_size_grid, 0, 0, 4, 1);
             style_popover_grid.attach (color_button_white, 0, 1, 1, 1);
             style_popover_grid.attach (color_button_light, 1, 1, 1, 1);
             style_popover_grid.attach (color_button_dark, 2, 1, 1, 1);
-            style_popover_grid.attach (color_button_black, 3, 1, 1, 1);
+            style_popover_grid.attach (color_button_black, 3, 1 , 1, 1);
             style_popover_grid.show_all ();
 
             var style_popover = new Gtk.Popover (null);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -16,14 +16,14 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace PantheonTerminal {
+namespace Terminal {
 
     public class MainWindow : Gtk.Window {
         private Pango.FontDescription term_font;
         private Granite.Widgets.DynamicNotebook notebook;
         private Gtk.Clipboard clipboard;
         private Gtk.Clipboard primary_selection;
-        private PantheonTerminal.Widgets.SearchToolbar search_toolbar;
+        private Terminal.Widgets.SearchToolbar search_toolbar;
         private Gtk.Revealer search_revealer;
         private Gtk.ToggleButton search_button;
         private Gtk.Button zoom_default_button;
@@ -48,7 +48,7 @@ namespace PantheonTerminal {
         public bool recreate_tabs { get; construct; default = true; }
         public bool restore_pos { get; construct; default = true; }
         public Gtk.Menu menu { get; private set; }
-        public TerminalApp app { get; construct; }
+        public Terminal.Application app { get; construct; }
         public SimpleActionGroup actions { get; construct; }
         public TerminalWidget current_terminal { get; private set; default = null; }
 
@@ -98,7 +98,7 @@ namespace PantheonTerminal {
             { ACTION_SCROLL_TO_LAST_COMMAND, action_scroll_to_last_command }
         };
 
-        public MainWindow (TerminalApp app, bool recreate_tabs = true) {
+        public MainWindow (Terminal.Application app, bool recreate_tabs = true) {
             Object (
                 app: app,
                 recreate_tabs: recreate_tabs
@@ -109,7 +109,7 @@ namespace PantheonTerminal {
             }
         }
 
-        public MainWindow.with_coords (TerminalApp app, int x, int y,
+        public MainWindow.with_coords (Terminal.Application app, int x, int y,
                                        bool recreate_tabs, bool ensure_tab) {
             Object (
                 app: app,
@@ -124,7 +124,7 @@ namespace PantheonTerminal {
             }
         }
 
-        public MainWindow.with_working_directory (TerminalApp app, string location,
+        public MainWindow.with_working_directory (Terminal.Application app, string location,
                                                   bool recreate_tabs = true) {
             Object (
                 app: app,
@@ -367,7 +367,7 @@ namespace PantheonTerminal {
             header.pack_end (style_button);
             header.pack_end (search_button);
 
-            search_toolbar = new PantheonTerminal.Widgets.SearchToolbar (this);
+            search_toolbar = new Terminal.Widgets.SearchToolbar (this);
 
             search_revealer = new Gtk.Revealer ();
             search_revealer.set_transition_type (Gtk.RevealerTransitionType.SLIDE_DOWN);
@@ -583,13 +583,13 @@ namespace PantheonTerminal {
             if (Granite.Services.System.history_is_enabled () &&
                 settings.remember_tabs) {
 
-                saved_tabs = PantheonTerminal.TerminalApp.saved_state.get_strv ("tabs");
+                saved_tabs = Terminal.Application.saved_state.get_strv ("tabs");
             } else {
                 saved_tabs = {};
             }
 
             var rect = Gdk.Rectangle ();
-            PantheonTerminal.TerminalApp.saved_state.get ("window-size", "(ii)", out rect.width, out rect.height);
+            Terminal.Application.saved_state.get ("window-size", "(ii)", out rect.width, out rect.height);
 
             default_width = rect.width;
             default_height = rect.height;
@@ -603,14 +603,14 @@ namespace PantheonTerminal {
             }
 
             if (restore_pos) {
-                PantheonTerminal.TerminalApp.saved_state.get ("window-position", "(ii)", out rect.x, out rect.y);
+                Terminal.Application.saved_state.get ("window-position", "(ii)", out rect.x, out rect.y);
 
                 if (rect.x != -1 ||  rect.y != -1) {
                     move (rect.x, rect.y);
                 }
             }
 
-            var window_state = PantheonTerminal.TerminalApp.saved_state.get_enum ("window-state");
+            var window_state = Terminal.Application.saved_state.get_enum ("window-state");
             if (window_state == MainWindow.MAXIMIZED) {
                 maximize ();
             } else if (window_state == MainWindow.FULLSCREEN) {
@@ -736,19 +736,19 @@ namespace PantheonTerminal {
 
                 /* Check for fullscreen first: https://github.com/elementary/terminal/issues/377 */
                 if ((get_window ().get_state () & Gdk.WindowState.FULLSCREEN) != 0) {
-                    PantheonTerminal.TerminalApp.saved_state.set_enum ("window-state", MainWindow.FULLSCREEN);
+                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.FULLSCREEN);
                 } else if (is_maximized) {
-                    PantheonTerminal.TerminalApp.saved_state.set_enum ("window-state", MainWindow.MAXIMIZED);
+                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.MAXIMIZED);
                 } else {
-                    PantheonTerminal.TerminalApp.saved_state.set_enum ("window-state", MainWindow.NORMAL);
+                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.NORMAL);
 
                     var rect = Gdk.Rectangle ();
                     get_size (out rect.width, out rect.height);
-                    PantheonTerminal.TerminalApp.saved_state.set ("window-size", "(ii)", rect.width, rect.height);
+                    Terminal.Application.saved_state.set ("window-size", "(ii)", rect.width, rect.height);
 
                     int root_x, root_y;
                     get_position (out root_x, out root_y);
-                    PantheonTerminal.TerminalApp.saved_state.set ("window-position", "(ii)", root_x, root_y);
+                    Terminal.Application.saved_state.set ("window-position", "(ii)", root_x, root_y);
                 }
 
                 return false;
@@ -770,7 +770,7 @@ namespace PantheonTerminal {
                 if (Granite.Services.System.history_is_enabled () &&
                     settings.remember_tabs) {
 
-                    PantheonTerminal.TerminalApp.saved_state.set_int (
+                    Terminal.Application.saved_state.set_int (
                         "focused-tab",
                         notebook.get_tab_position (new_tab)
                     );
@@ -791,9 +791,9 @@ namespace PantheonTerminal {
                     tabs += Environment.get_home_dir ();
                 }
 
-                focus = PantheonTerminal.TerminalApp.saved_state.get_int ("focused-tab");
+                focus = Terminal.Application.saved_state.get_int ("focused-tab");
             } else {
-                tabs += TerminalApp.working_directory ?? Environment.get_current_dir ();
+                tabs += Terminal.Application.working_directory ?? Environment.get_current_dir ();
             }
 
             int null_dirs = 0;
@@ -806,11 +806,11 @@ namespace PantheonTerminal {
                 }
 
                 if (null_dirs == tabs.length) {
-                    tabs[0] = TerminalApp.working_directory ?? Environment.get_current_dir ();
+                    tabs[0] = Terminal.Application.working_directory ?? Environment.get_current_dir ();
                 }
             }
 
-            PantheonTerminal.TerminalApp.saved_state.set_strv ("tabs", {});
+            Terminal.Application.saved_state.set_strv ("tabs", {});
 
             focus = focus.clamp (0, tabs.length - 1);
 
@@ -843,7 +843,7 @@ namespace PantheonTerminal {
              */
             string location;
             if (directory == "") {
-                location = TerminalApp.working_directory ?? Environment.get_current_dir ();
+                location = Terminal.Application.working_directory ?? Environment.get_current_dir ();
             } else {
                 location = directory;
             }
@@ -1264,12 +1264,12 @@ namespace PantheonTerminal {
                     }
                 });
             }
-            PantheonTerminal.TerminalApp.saved_state.set_strv (
+            Terminal.Application.saved_state.set_strv (
                 "tabs",
                 opened_tabs
             );
 
-            PantheonTerminal.TerminalApp.saved_state.set_int (
+            Terminal.Application.saved_state.set_int (
                 "focused-tab",
                 notebook.get_tab_position (notebook.current)
             );

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -38,6 +38,8 @@ namespace Terminal {
 
         private const string HIGH_CONTRAST_BG = "#fff";
         private const string HIGH_CONTRAST_FG = "#333";
+        private const string SOLARIZED_BLACK_BG = "rgba(51, 51, 51, 0.95)";
+        private const string SOLARIZED_BLACK_FG = "#d4d4d4";
         private const string SOLARIZED_DARK_BG = "rgba(37, 46, 50, 0.95)";
         private const string SOLARIZED_DARK_FG = "#94a3a5";
         private const string SOLARIZED_LIGHT_BG = "rgba(253, 246, 227, 0.95)";
@@ -338,15 +340,24 @@ namespace Terminal {
             color_button_dark_context.add_class ("color-button");
             color_button_dark_context.add_class ("color-dark");
 
+            var color_button_black = new Gtk.RadioButton.from_widget (color_button_white);
+            color_button_black.halign = Gtk.Align.CENTER;
+            color_button_black.tooltip_text = _("Solarized Black");
+
+            var color_button_black_context = color_button_black.get_style_context ();
+            color_button_black_context.add_class ("color-button");
+            color_button_black_context.add_class ("color-black");
+
             var style_popover_grid = new Gtk.Grid ();
             style_popover_grid.margin = 12;
-            style_popover_grid.column_spacing = 6;
+            style_popover_grid.column_spacing = 8;  //6
             style_popover_grid.row_spacing = 12;
             style_popover_grid.width_request = 200;
             style_popover_grid.attach (font_size_grid, 0, 0, 3, 1);
             style_popover_grid.attach (color_button_white, 0, 1, 1, 1);
             style_popover_grid.attach (color_button_light, 1, 1, 1, 1);
             style_popover_grid.attach (color_button_dark, 2, 1, 1, 1);
+            style_popover_grid.attach (color_button_black, 3, 1, 1, 1);
             style_popover_grid.show_all ();
 
             var style_popover = new Gtk.Popover (null);
@@ -416,7 +427,16 @@ namespace Terminal {
                 case SOLARIZED_DARK_BG:
                     color_button_dark.active = true;
                     break;
+                case SOLARIZED_BLACK_BG:
+                    color_button_black.active = true;
+                    break;
             }
+
+            color_button_black.clicked.connect (() => {
+                settings.prefer_dark_style = true;
+                settings.background = SOLARIZED_BLACK_BG;
+                settings.foreground = SOLARIZED_BLACK_FG;
+            });
 
             color_button_dark.clicked.connect (() => {
                 settings.prefer_dark_style = true;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -192,23 +192,29 @@ namespace PantheonTerminal {
 
             primary_selection = Gtk.Clipboard.get (Gdk.Atom.intern ("PRIMARY", false));
 
-            var copy_menuitem = new Gtk.MenuItem.with_label (_("Copy"));
+            var copy_menuitem = new Gtk.MenuItem ();
             copy_menuitem.set_action_name (ACTION_PREFIX + ACTION_COPY);
+            copy_menuitem.add (new AccelMenuLabel (_("Copy"), copy_menuitem.action_name));
 
-            var copy_last_output_menuitem = new Gtk.MenuItem.with_label (_("Copy Last Output"));
+            var copy_last_output_menuitem = new Gtk.MenuItem ();
             copy_last_output_menuitem.set_action_name (ACTION_PREFIX + ACTION_COPY_LAST_OUTPUT);
+            copy_last_output_menuitem.add (new AccelMenuLabel (_("Copy Last Output"), copy_last_output_menuitem.action_name));
 
-            var paste_menuitem = new Gtk.MenuItem.with_label (_("Paste"));
+            var paste_menuitem = new Gtk.MenuItem ();
             paste_menuitem.set_action_name (ACTION_PREFIX + ACTION_PASTE);
+            paste_menuitem.add (new AccelMenuLabel (_("Paste"), paste_menuitem.action_name));
 
-            var select_all_menuitem = new Gtk.MenuItem.with_label (_("Select All"));
+            var select_all_menuitem = new Gtk.MenuItem ();
             select_all_menuitem.set_action_name (ACTION_PREFIX + ACTION_SELECT_ALL);
+            select_all_menuitem.add (new AccelMenuLabel (_("Select All"), select_all_menuitem.action_name));
 
-            var search_menuitem = new Gtk.MenuItem.with_label (_("Find…"));
+            var search_menuitem = new Gtk.MenuItem ();
             search_menuitem.set_action_name (ACTION_PREFIX + ACTION_SEARCH);
+            search_menuitem.add (new AccelMenuLabel (_("Find…"), search_menuitem.action_name));
 
-            var show_in_file_browser_menuitem = new Gtk.MenuItem.with_label (_("Show in File Browser"));
+            var show_in_file_browser_menuitem = new Gtk.MenuItem ();
             show_in_file_browser_menuitem.set_action_name (ACTION_PREFIX + ACTION_OPEN_IN_FILES);
+            show_in_file_browser_menuitem.add (new AccelMenuLabel (_("Show in File Browser"), show_in_file_browser_menuitem.action_name));
 
             menu = new Gtk.Menu ();
             menu.append (copy_menuitem);
@@ -1316,6 +1322,35 @@ namespace PantheonTerminal {
 
         public GLib.SimpleAction? get_simple_action (string action) {
             return actions.lookup_action (action) as GLib.SimpleAction;
+        }
+
+        private class AccelMenuLabel : Gtk.Grid {
+            public string action_name { get; construct; }
+            public string label { get; construct; }
+
+            public AccelMenuLabel (string label, string action_name) {
+                Object (
+                    label: label,
+                    action_name: action_name
+                );
+            }
+
+            construct {
+                var label = new Gtk.Label (label);
+                label.hexpand = true;
+                label.xalign = 0;
+
+                var accel_label = new Gtk.Label (
+                    Granite.accel_to_string (
+                        ((Gtk.Application) GLib.Application.get_default ()).get_accels_for_action (action_name)[0]
+                    )
+                );
+                accel_label.get_style_context ().add_class (Gtk.STYLE_CLASS_ACCELERATOR);
+
+                column_spacing = 3;
+                add (label);
+                add (accel_label);
+            }
         }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -53,7 +53,6 @@ namespace Terminal {
         public TerminalWidget current_terminal { get; private set; default = null; }
 
         public GLib.List <TerminalWidget> terminals = new GLib.List <TerminalWidget> ();
-        public GLib.SimpleActionGroup main_actions;
 
         public const string ACTION_PREFIX = "win.";
         public const string ACTION_CLOSE_TAB = "action-close-tab";
@@ -556,7 +555,7 @@ namespace Terminal {
             });
         }
 
-        public bool handle_paste_event () {
+        private bool handle_paste_event () {
             if (search_toolbar.search_entry.has_focus) {
                 return false;
             } else if (clipboard.wait_is_text_available ()) {
@@ -721,8 +720,7 @@ namespace Terminal {
             get_simple_action (ACTION_COPY_LAST_OUTPUT).set_enabled (current_terminal.has_output ());
         }
 
-        uint timer_window_state_change = 0;
-
+        private uint timer_window_state_change = 0;
         private bool on_window_state_change (Gdk.EventConfigure event) {
             // triggered when the size, position or stacking of the window has changed
             // it is delayed 400ms to prevent spamming gsettings
@@ -943,11 +941,7 @@ namespace Terminal {
             });
         }
 
-        public void run_program_term (string program) {
-            new_tab ("", program);
-        }
-
-        static string get_term_font () {
+        private static string get_term_font () {
             string font_name;
 
             if (settings.font == "") {
@@ -994,7 +988,7 @@ namespace Terminal {
             }
         }
 
-        void on_get_text (Gtk.Clipboard board, string? intext) {
+        private void on_get_text (Gtk.Clipboard board, string? intext) {
             /* if unsafe paste alert is enabled, show dialog */
             if (settings.unsafe_paste_alert && !unsafe_ignored ) {
 
@@ -1026,11 +1020,11 @@ namespace Terminal {
             }
         }
 
-        void action_quit () {
+        private void action_quit () {
 
         }
 
-        void action_copy () {
+        private void action_copy () {
             if (current_terminal.uri != null && ! current_terminal.get_has_selection ())
                 clipboard.set_text (current_terminal.uri,
                                     current_terminal.uri.length);
@@ -1038,20 +1032,20 @@ namespace Terminal {
                 current_terminal.copy_clipboard ();
         }
 
-        void action_copy_last_output () {
+        private void action_copy_last_output () {
             string output = current_terminal.get_last_output ();
             Gtk.Clipboard.get_default (Gdk.Display.get_default ()).set_text (output, output.length);
         }
 
-        void action_paste () {
+        private void action_paste () {
             clipboard.request_text (on_get_text);
         }
 
-        void action_select_all () {
+        private void action_select_all () {
             current_terminal.select_all ();
         }
 
-        void action_open_in_files () {
+        private void action_open_in_files () {
             try {
                 string uri = Filename.to_uri (current_terminal.get_shell_location ());
 
@@ -1066,39 +1060,39 @@ namespace Terminal {
             }
         }
 
-        void action_scroll_to_last_command () {
+        private void action_scroll_to_last_command () {
             current_terminal.scroll_to_last_command ();
             /* Repeated presses are ignored */
             get_simple_action (ACTION_SCROLL_TO_LAST_COMMAND).set_enabled (false);
         }
 
-        void action_close_tab () {
+        private void action_close_tab () {
             current_terminal.tab.close ();
             current_terminal.grab_focus ();
         }
 
-        void action_new_window () {
+        private void action_new_window () {
             app.new_window ();
         }
 
-        void action_new_tab () {
+        private void action_new_tab () {
             if (settings.follow_last_tab)
                 new_tab (current_terminal.get_shell_location ());
             else
                 new_tab (Environment.get_home_dir ());
         }
 
-        void action_zoom_in_font () {
+        private void action_zoom_in_font () {
             current_terminal.increment_size ();
             set_zoom_default_label (current_terminal.font_scale);
         }
 
-        void action_zoom_out_font () {
+        private void action_zoom_out_font () {
             current_terminal.decrement_size ();
             set_zoom_default_label (current_terminal.font_scale);
         }
 
-        void action_zoom_default_font () {
+        private void action_zoom_default_font () {
             current_terminal.set_default_font_size ();
             set_zoom_default_label (current_terminal.font_scale);
         }
@@ -1107,15 +1101,15 @@ namespace Terminal {
             zoom_default_button.label = "%.0f%%".printf (current_terminal.font_scale * 100);
         }
 
-        void action_next_tab () {
+        private void action_next_tab () {
             notebook.next_page ();
         }
 
-        void action_previous_tab () {
+        private void action_previous_tab () {
             notebook.previous_page ();
         }
 
-        void action_search () {
+        private void action_search () {
             var search_action = (SimpleAction) actions.lookup_action (ACTION_SEARCH);
             var search_state = search_action.get_state ().get_boolean ();
 
@@ -1163,19 +1157,19 @@ namespace Terminal {
             );
         }
 
-        void action_search_next () {
+        private void action_search_next () {
             if (search_button.active) {
                 search_toolbar.next_search ();
             }
         }
 
-        void action_search_previous () {
+        private void action_search_previous () {
             if (search_button.active) {
                 search_toolbar.previous_search ();
             }
         }
 
-        void action_fullscreen () {
+        private void action_fullscreen () {
             if (is_fullscreen) {
                 unfullscreen ();
                 is_fullscreen = false;
@@ -1189,7 +1183,7 @@ namespace Terminal {
             return (TerminalWidget)((Gtk.Bin)tab.page).get_child ();
         }
 
-        uint name_check_timeout_id = 0;
+        private uint name_check_timeout_id = 0;
         private void schedule_name_check () {
             if (name_check_timeout_id > 0) {
                 Source.remove (name_check_timeout_id);

--- a/src/Settings.vala
+++ b/src/Settings.vala
@@ -16,7 +16,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace PantheonTerminal {
+namespace Terminal {
     public Settings settings;
 
     public enum cursor_shape {

--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace PantheonTerminal.Widgets {
+namespace Terminal.Widgets {
 
     public class SearchToolbar : Gtk.Grid {
         private Gtk.ToggleButton cycle_button;

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace PantheonTerminal {
+namespace Terminal {
 
     public class TerminalWidget : Vte.Terminal {
         enum DropTargets {
@@ -27,7 +27,7 @@ namespace PantheonTerminal {
         }
 
         internal const string DEFAULT_LABEL = _("Terminal");
-        public TerminalApp app;
+        public Terminal.Application app;
         public string terminal_id;
         static int terminal_id_counter = 0;
         private bool init_complete;
@@ -189,7 +189,7 @@ namespace PantheonTerminal {
             this.drag_data_received.connect (drag_received);
             this.clickable (regex_strings);
 
-            PantheonTerminal.TerminalApp.saved_state.bind ("zoom", this, "font-scale", GLib.SettingsBindFlags.DEFAULT);
+            Terminal.Application.saved_state.bind ("zoom", this, "font-scale", GLib.SettingsBindFlags.DEFAULT);
         }
 
         public void restore_settings () {


### PR DESCRIPTION
Better matches elementary/stylesheet#510, plus better contrast and add button on "Style"

## Before 
Only 3 color buttons
![Screenshot from 2019-09-09 21-55-58](https://user-images.githubusercontent.com/46902231/64558508-ad4d2480-d34c-11e9-8fd7-e55603637c8d.png)

## After
![Screenshot from 2019-09-09 21-07-06](https://user-images.githubusercontent.com/46902231/64558019-965a0280-d34b-11e9-9223-1a080ae1e3c7.png)

Thank you @cassidyjames for colors  
https://github.com/elementary/terminal/pull/390#issue-300914485