### PR TITLE
Add horizontal padding

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -25,6 +25,11 @@
     background-color: #000;
 }
 
+vte-terminal {
+    padding-left: 4px;
+    padding-right: 4px;
+}
+
 .color-button radio,
 .color-button radio:checked {
     border-color: alpha (#000, 0.3);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -275,7 +275,10 @@ namespace Terminal {
         private void setup_ui () {
             var provider = new Gtk.CssProvider ();
             provider.load_from_resource ("io/elementary/terminal/Application.css");
-            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            // Vte.Terminal itself registers its default styling with the APPLICATION priority:
+            // https://gitlab.gnome.org/GNOME/vte/blob/0.52.2/src/vtegtk.cc#L374-377
+            // To be able to overwrite their styles, we need to use +1.
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION + 1);
 
             search_button = new Gtk.ToggleButton ();
             search_button.action_name = ACTION_PREFIX + ACTION_SEARCH;


### PR DESCRIPTION
Terminal windows only have 1px of padding for their content, unlike other elementary apps:

![term-default](https://user-images.githubusercontent.com/70772/66273485-a72b6480-e874-11e9-9a35-544c740c8d19.png)

This PR adds 3px to the horizontal padding, which is subtle, but noticeable:

![term-padding](https://user-images.githubusercontent.com/70772/66273489-adb9dc00-e874-11e9-80ed-751e6231406d.png)

Adding more than that feels like there should be vertical padding as well, but vertical padding is trickier, since the terminal window scrolls vertically.

What do you think? (Mostly from a UI perspective. The code isn't great; if I understand things correctly, we should open a PR on the VTE project to fix their internal CSS priority, and then it could be done without the +1 priority hack.)