### PR TITLE
GSchema: Fix default foreground color

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -91,7 +91,7 @@
     </key>
 
     <key name="foreground" type="s">
-      <default>"#d4d4d4"</default>
+      <default>"#a5a5a5"</default>
       <summary>Color of the text.</summary>
       <description>
           The color of the text of the terminal.


### PR DESCRIPTION
Follow-up to #412, fixes #471