### PR TITLE
-e execute skips active tabs search

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -288,16 +288,19 @@ namespace Terminal {
                 location = directory;
             }
 
-            var f1 = File.new_for_commandline_arg (location);
-            foreach (Granite.Widgets.Tab tab in notebook.tabs) {
-                var t = get_term_widget (tab);
-                var tab_path = t.get_shell_location ();
-                /* Detect equialent paths */
-                if (f1.equal (File.new_for_path (tab_path))) {
-                    /* Just focus the duplicate tab instead */
-                    notebook.current = tab;
-                    t.grab_focus ();
-                    return; /* Duplicate found, abandon adding tab */
+            /* Only empty commands can select existing tabs/paths */
+            if (command == null) {
+                var f1 = File.new_for_commandline_arg (location);
+                foreach (Granite.Widgets.Tab tab in notebook.tabs) {
+                    var t = get_term_widget (tab);
+                    var tab_path = t.get_shell_location ();
+                    /* Detect equialent paths */
+                    if (f1.equal (File.new_for_path (tab_path))) {
+                        /* Just focus the duplicate tab instead */
+                        notebook.current = tab;
+                        t.grab_focus ();
+                        return; /* Duplicate found, abandon adding tab */
+                    }
                 }
             }
 


### PR DESCRIPTION
With the new changes from 2df52a9c334be97e702793bc6938c50f1e668251 it is now impossible to start the terminal with a command of already open tab:
```
io.elementary.terminal -e ls -w /tmp
```
If there is already a tab with the path of /tmp then such tab is activated and no command is run. Hence we have a new bug.

This commit makes it possible to run such commands in a working directory which has already a tab open.