### PR TITLE
Support for new "-t" option (create new tab)

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -35,6 +35,9 @@ public class Terminal.Application : Gtk.Application {
     // option_new_window will be true if the new-window flag was given.
     private static bool option_new_window = false;
 
+    // option_new_tab will be true if the new-tab flag was given.
+    private static bool option_new_tab = false;
+
     public int minimum_width;
     public int minimum_height;
 
@@ -190,6 +193,7 @@ public class Terminal.Application : Gtk.Application {
         command_x = null;
         option_help = false;
         option_new_window = false;
+        option_new_tab = false;
         working_directory = null;
 
         return 0;
@@ -217,7 +221,7 @@ public class Terminal.Application : Gtk.Application {
         }
 
         foreach (string command in commands) {
-            window.add_tab_with_command (command, working_directory);
+            window.add_tab_with_command (command, working_directory, option_new_tab);
         }
     }
 
@@ -229,7 +233,7 @@ public class Terminal.Application : Gtk.Application {
             window = new MainWindow (this, false);
         }
 
-        window.add_tab_with_command (command_line, working_directory);
+        window.add_tab_with_command (command_line, working_directory, option_new_tab);
     }
 
     private void start_terminal_with_working_directory (string? working_directory) {
@@ -237,14 +241,14 @@ public class Terminal.Application : Gtk.Application {
         window = get_last_window ();
 
         if (window != null && !option_new_window) {
-            window.add_tab_with_working_directory (working_directory);
+            window.add_tab_with_working_directory (working_directory, null, option_new_tab);
             window.present ();
         } else
             /* Uncertain whether tabs should be restored when app is launched with working directory from commandline.
              * Currently they are set to restore (subject to the restore-tabs setting).
              * If it is desired that tabs should never be restored in these circimstances set 3rd parameter to false
              * below. */
-            new MainWindow.with_working_directory (this, working_directory, window == null);
+            new MainWindow.with_working_directory (this, working_directory, window == null, option_new_tab);
     }
 
     private MainWindow? get_last_window () {
@@ -264,6 +268,9 @@ public class Terminal.Application : Gtk.Application {
 
         /* -n flag forces a new window, instead of a new tab */
         { "new-window", 'n', 0, OptionArg.NONE, ref option_new_window, N_("Open a new terminal window"), null },
+
+        /* -t flag forces a new tab  */
+        { "new-tab", 't', 0, OptionArg.NONE, ref option_new_tab, N_("Open a new terminal tab"), null },
 
         { "help", 'h', 0, OptionArg.NONE, ref option_help, N_("Show help"), null },
         { "working-directory", 'w', 0, OptionArg.FILENAME, ref working_directory,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -126,14 +126,14 @@ namespace Terminal {
         }
 
         public MainWindow.with_working_directory (Terminal.Application app, string? location,
-                                                  bool recreate_tabs = true) {
+                                                  bool recreate_tabs = true, bool create_new_tab = false) {
             Object (
                 app: app,
                 focus_restored_tabs: false,
                 recreate_tabs: recreate_tabs
             );
 
-            add_tab_with_working_directory (location);
+            add_tab_with_working_directory (location, null, create_new_tab);
         }
 
         static construct {
@@ -269,11 +269,11 @@ namespace Terminal {
             }
         }
 
-        public void add_tab_with_command (string command, string? working_directory = null) {
-            add_tab_with_working_directory (working_directory, command);
+        public void add_tab_with_command (string command, string? working_directory = null, bool create_new_tab = false) {
+            add_tab_with_working_directory (working_directory, command, create_new_tab);
         }
 
-        public void add_tab_with_working_directory (string? directory, string? command = null) {
+        public void add_tab_with_working_directory (string? directory, string? command = null, bool create_new_tab = false) {
             /* This requires all restored tabs to be initialized first so that the shell location is available */
             /* Do not add a new tab if location is already open in existing tab */
             string? location = null;
@@ -288,8 +288,8 @@ namespace Terminal {
                 location = directory;
             }
 
-            /* Only empty commands can select existing tabs/paths */
-            if (command == null) {
+            /* We can match existing tabs only if there is no command and create_new_tab == false */
+            if (command == null && !create_new_tab) {
                 var f1 = File.new_for_commandline_arg (location);
                 foreach (Granite.Widgets.Tab tab in notebook.tabs) {
                     var t = get_term_widget (tab);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -279,7 +279,7 @@ namespace Terminal {
             string? location = null;
 
             if (directory == null || directory == "") {
-                if (notebook.tabs.first () == null) { //Ensure at least one tab.
+                if (notebook.tabs.first () == null || command!=null || create_new_tab) { //Ensure at least one tab
                     new_tab ("", command);
                 }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -279,7 +279,7 @@ namespace Terminal {
             string? location = null;
 
             if (directory == null || directory == "") {
-                if (notebook.tabs.first () == null || command!=null || create_new_tab) { //Ensure at least one tab
+                if (notebook.tabs.first () == null || command != null || create_new_tab) { //Ensure at least one tab
                     new_tab ("", command);
                 }
 


### PR DESCRIPTION
With the new behavior of the terminal trying to match existing tab's path it is impossible to open a new tab with such existing path (working directory option -w).

- Suppose you have the terminal app open with the tab of location /tmp (running some command or simply waiting)
- Now you want to open another instance of the same path using:
```
io.elementary.terminal -w /tmp
```
This will simply activate the existing tab and nothing else will happen. Hence we cannot achieve the desired resuilt.

A new "-t" option to force a tab creation is the right solution (just lke we have for a new window).
This PR introduces the new option.

Newly, you can open the terminal with:
```
io.elementary.terminal -t -w /tmp
```
