### PR TITLE
keep terminal focus when tab is closed

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -802,6 +802,7 @@ namespace Terminal {
                 }
             }
 
+            current_terminal.grab_focus ();
             return true;
         }
 


### PR DESCRIPTION
fix #495

keep focus on the terminal when a tab is closed.