### PR TITLE
MainWindow: Use the Gtk.EventControllerKey controller to handle the key events

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -60,7 +60,7 @@ executable(
         dependency('gee-0.8'),
         dependency('glib-2.0'),
         dependency('gobject-2.0'),
-        dependency('gtk+-3.0'),
+        dependency('gtk+-3.0', version: '>=3.24'),
         dependency('granite', version: '>=5.5.0'),
         dependency('libhandy-1', version: '>=0.83.0'),
         vte_dep,

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -152,8 +152,8 @@ namespace Terminal {
                         window.get_simple_action (MainWindow.ACTION_COPY).set_enabled (true);
                     }
 
-                    menu.select_first (false);
                     menu.popup_at_pointer (event);
+                    menu.select_first (false);
 
                     return true;
                 }


### PR DESCRIPTION
This makes the copy function work again.
Fix GtkMenu warnings on the go.