### PR TITLE
Adds setting "block-multiline-paste-alert" (default: true)

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -179,5 +179,10 @@
       <summary>Alert the user about unsafe paste.</summary>
       <description>If the user paste's a command into the terminal that might be considered unsafe, warn them.</description>
     </key>
+    <key name="block-multiline-paste-alert" type="b">
+      <default>true</default>
+      <summary>Alert the user about multiline paste.</summary>
+      <description>If the user pastes text into the terminal which contains newlines, warn them, since it could lead to an unintentionally command execution.</description>
+    </key>
   </schema>
 </schemalist>

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ executable(
     'src/Application.vala',
     'src/DBus.vala',
     'src/MainWindow.vala',
+    'src/Dialogs/BlockMultilinePasteDialog.vala',
     'src/Dialogs/ForegroundProcessDialog.vala',
     'src/Dialogs/UnsafePasteDialog.vala',
     'src/Widgets/SearchToolbar.vala',

--- a/po/en_GB.po
+++ b/po/en_GB.po
@@ -153,6 +153,18 @@ msgstr "If you quit Terminal, the process will end."
 msgid "Quit Terminal"
 msgstr "Quit Terminal"
 
+#: src/Dialogs/BlockMultilinePasteDialog.vala:29
+msgid "Multiline Paste Blocked"
+msgstr "Multiline Paste Blocked"
+
+#: src/Dialogs/BlockMultilinePasteDialog.vala:32
+msgid "The text you want to paste may be treated as command and could unintentionally be executed."
+msgstr "The text you want to paste may be treated as command and could unintentionally be executed."
+
+#: src/Dialogs/BlockMultilinePasteDialog.vala:33
+msgid "Be sure your paste doesn't contain newline characters."
+msgstr "Be sure your paste doesn't contain newline characters."
+
 #: src/Dialogs/UnsafePasteDialog.vala:29
 msgid "This command is asking for Administrative access to your computer"
 msgstr "This command is asking for Administrative access to your computer"

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1187,6 +1187,20 @@ namespace Terminal {
         }
 
         private void on_get_text (Gtk.Clipboard board, string? intext) {
+            /* don't accidentally cause command executions from pasting multiline text */
+            if (Application.settings.get_boolean ("block-multiline-paste-alert")) {
+				
+				if (intext.index_of ("\n") != -1) {
+					var d = new BlockMultilinePasteDialog (this);
+                    if (d.run () == 1) {
+                        d.destroy ();
+                        return;
+                    }
+                    d.destroy ();
+				}
+				
+			}
+			            
             /* if unsafe paste alert is enabled, show dialog */
             if (Application.settings.get_boolean ("unsafe-paste-alert") && !unsafe_ignored ) {
 


### PR DESCRIPTION
Adds setting "block-multiline-paste-alert" (default: true) which opens a dialog if the user attempts to paste multiline content into the terminal, since newline characters could lead to an unintentionally command execution and harm the system.

**Example**

Someone would copy a `rm -R ...` command from a tutorial (or from the terminal itself) with the intention to edit it _after_ the paste. However, if the paste contains newline characters, it would be **unintentionally executed**. The new warning prevents this.

**Setting**

You can turn on/off this setting using:

```
gsettings set io.elementary.terminal.settings block-multiline-paste-alert true
gsettings set io.elementary.terminal.settings block-multiline-paste-alert false
```