### PR TITLE
Update window title and tab labels properly when custom prompt

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1087,7 +1087,7 @@ namespace Terminal {
                 * is a custom prompt or the window title is permanently empty for some other reason.
                 */
                 if (t.window_title == "") {
-                    schedule_name_check (); 
+                    schedule_name_check ();
                 }
             });
 


### PR DESCRIPTION
Fixes #567 

* Do not rely on terminal.window_title property
* Get tab basename from shell location
* Check when content changes when window_title is empty (custom prompt)

For some reason, when there is a custom prompt defined in `~/.bashrc`, the Vte terminal widget does not update the window title property when the CWD changes.  Terminal was relying on being notified of that change to schedule setting the tab labels (including disambiguation).

In this, not very satisfactory, solution, when the window title is empty, the name checking is scheduled every time the tab content changes.  To avoid too much unnecessary work, the name checking does not occur until 100ms has passed without the function being called and the contents changed signal handler does not trigger unless the window title is empty.

For comparison:  Left = Mate Terminal, Right = this PR both with two tabs one at `/home/jeremy` and one at `/home/jeremy/TestFolder/jeremy` and with a custom prompt defined by `PS1="custom prompt >" in `~/.bashrc`

![Screenshot from 2021-03-24 18 22 01](https://user-images.githubusercontent.com/10513844/112364124-1b0e3680-8cce-11eb-981c-decea38631bc.png)
