### PR TITLE
Paste Protection dialog cancels pasting if Escape is pressed

### DIFF
--- a/src/Dialogs/UnsafePasteDialog.vala
+++ b/src/Dialogs/UnsafePasteDialog.vala
@@ -45,6 +45,8 @@ public class Terminal.UnsafePasteDialog : Granite.MessageDialog {
         ignore_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         ignore_button.clicked.connect (on_ignore);
 
+        set_default_response (1);
+
         Terminal.Application.settings.bind (
             "unsafe-paste-alert", show_protection_warnings, "active", SettingsBindFlags.DEFAULT
         );

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1218,7 +1218,7 @@ namespace Terminal {
 
                 if ((text.index_of ("sudo") > -1) && (text.index_of ("\n") != 0)) {
                     var d = new UnsafePasteDialog (this, text);
-                    if (d.run () == 1) {
+                    if (d.run () != 0) {
                         d.destroy ();
                         return;
                     }


### PR DESCRIPTION
This also sets the default action to "Do not Paste" (as suggested in the linked issue). Fixes #293 .