### PR TITLE
Add Reload item to terminal tabs.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1135,6 +1135,11 @@ namespace Terminal {
             term.tab = tab;
             tab.ellipsize_mode = Pango.EllipsizeMode.START;
 
+            var reload_menu_item = new Gtk.MenuItem.with_label (_("Reload"));
+            tab.menu.append (reload_menu_item);
+            reload_menu_item.activate.connect (term.reload);
+            tab.menu.show_all ();
+
             return tab;
         }
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -592,5 +592,12 @@ namespace Terminal {
         public bool has_output () {
             return !resized && get_last_output ().length > 0;
         }
+
+        public void reload () {
+            var old_loc = get_shell_location ();
+            Posix.kill (child_pid, Posix.Signal.TERM);
+            reset (true, true);
+            active_shell (old_loc);
+        }
     }
 }


### PR DESCRIPTION
Fix #544 . The solution adopted was to kill the current shell child process and create a new one using the same terminal. 

![terminal-reload](https://user-images.githubusercontent.com/221446/112755561-864e5600-8fb7-11eb-8bbc-8baf6e6fcb7a.gif)

I'm not sure if the Reload option was added in the correct place. It seems all exiting options come from DynamicNotebook, so I just added an extra option after a tab is created. 