### PR TITLE
Preliminary Flatpak manifest

### DIFF
--- a/io.elementary.terminal.appdata.xml
+++ b/io.elementary.terminal.appdata.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="application">
+    <id>io.elementary.terminal</id>
+    <metadata_license>FSFAP</metadata_license>
+    <project_license>GPL-3.0-only</project_license>
+    <name>elementary Terminal</name>
+    <summary>The terminal of the 21st century.</summary>
+    <description>
+        <p>A super lightweight, beautiful, and simple terminal. Comes with sane defaults, browser-class tabs, sudo paste protection, smart copy/paste, and little to no configuration.</p>
+    </description>
+    <screenshots>
+        <screenshot type="default">
+            <image>https://raw.githubusercontent.com/elementary/terminal/master/data/screenshot.png</image>
+        </screenshot>
+    </screenshots>
+    <url type="homepage">https://github.com/elementary/terminal</url>
+    <url type="bugtracker">https://github.com/elementary/terminal/issues</url>
+    <developer_name>elementary, Inc.</developer_name>
+    <releases>
+        <release version="5.5.2" date="2020-04-01" />
+    </releases>
+    <translation>https://elementary.io/docs/translation-guide</translation>
+    <update_contact>flatpak_at_elementary_dot_io</update_contact>
+</component>

--- a/io.elementary.terminal.json
+++ b/io.elementary.terminal.json
@@ -1,0 +1,69 @@
+{
+  "id": "io.elementary.terminal",
+  "runtime": "org.gnome.Platform",
+  "sdk": "org.gnome.Sdk",
+  "runtime-version": "40",
+  "appstream-compose": false,
+  "separate-locales": false,
+  "modules": [
+    {
+      "name": "libvte-2.91-dev",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://gitlab.gnome.org/GNOME/vte/-/archive/0.64.0/vte-0.64.0.tar.gz",
+          "sha256": "2297503448325972cbe13b87f70f6882ac91836c6e2adbddfbe5323bfbb17547"
+        }
+      ]
+    },
+    {
+      "name": "granite",
+      "buildsystem": "meson",
+      "cleanup": [
+        "/bin",
+        "/share/applications"
+      ],
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/elementary/granite/archive/5.5.0.tar.gz",
+          "sha256": "0c376520c7d462fca05213a14970ee1075fea4a78062a33b47529e2647cd5557"
+        }
+      ]
+    },
+    {
+      "name": "Terminal",
+      "buildsystem": "meson",
+      "sources": [
+        {
+          "type": "archive",
+          "url": "https://github.com/elementary/terminal/archive/refs/tags/5.5.2.tar.gz",
+          "sha256": "589ad0225e3a45700d95c8ead1b646f22a22c7688f647876a5329b3b4bd923cd"
+        }
+      ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm644 --target-directory=${FLATPAK_DEST}/share/appdata io.elementary.terminal.appdata.xml",
+        "appstream-compose --basename=io.elementary.terminal --prefix=${FLATPAK_DEST} --origin=flatpak io.elementary.terminal"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "io.elementary.terminal.appdata.xml"
+        }
+      ]
+    }
+  ],
+  "finish-args": [
+	 "--share=ipc",
+	 "--socket=x11",
+	 "--socket=wayland",
+	 "--share=network",
+	 "--allow=bluetooth",
+	 "--filesystem=host"
+  ]
+}


### PR DESCRIPTION
Fixes https://github.com/elementary/terminal/issues/541

On a preliminary basis, this appears to work correctly.

You can test the build using the command:
```
$ flatpak-builder --force-clean build io.elementary.terminal.json
```
And then build and install using the command:
```
$ sudo flatpak-builder --install --force-clean build io.elementary.terminal.json
```

The main obvious build issues seem to be:
1. `open-pantheon-terminal-here.desktop` doesn't work because it's a non-allowed export filename, and
2. The exported icons in general (but mainly the custom app icon) don't work because they also have non-allowed export filenames.

I used `org.gnome.Platform` and `org.gnome.Sdk` because they include certain dependencies that you would otherwise be building from scratch, but one of the other of them is probably unnecessary, and [`io.elementary.BaseApp`](https://github.com/flathub/io.elementary.BaseApp), might help, as well.