### PR TITLE
Catch Uri.unescape_string returning null

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1258,11 +1258,13 @@ namespace Terminal {
 
         private void action_open_in_browser () {
             get_current_selection_link_or_pwd ((clipboard, uri) => {
-                string to_open = Utils.sanitize_path (uri, current_terminal.get_shell_location ());
-                try {
-                    Gtk.show_uri_on_window (null, to_open, Gtk.get_current_event_time ());
-                } catch (GLib.Error error) {
-                    warning ("Could not show %s - %s", to_open, error.message);
+                string? to_open = Utils.sanitize_path (uri, current_terminal.get_shell_location ());
+                if (to_open != null) {
+                    try {
+                        Gtk.show_uri_on_window (null, to_open, Gtk.get_current_event_time ());
+                    } catch (GLib.Error error) {
+                        warning ("Could not show %s - %s", to_open, error.message);
+                    }
                 }
             });
         }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -18,7 +18,7 @@
 
 
 namespace Terminal.Utils {
-    public string sanitize_path (string _path, string shell_location) {
+    public string? sanitize_path (string _path, string shell_location) {
         /* Remove trailing whitespace, ensure scheme, substitute leading "~" and "..", remove extraneous "/" */
         string scheme, path;
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -32,6 +32,10 @@ namespace Terminal.Utils {
         }
 
         path = Uri.unescape_string (path);
+        if (path == null) {
+            return null;
+        }
+
         path = strip_uri (path);
 
         do {


### PR DESCRIPTION
Not checking this can lead to crashes when a string cannot be escaped, for example if the string is the contents of an open Vim window. As such, when doing "select all" while having Vim open would crash the terminal as it tried to check if the new selection contains a link.