### PR TITLE
Refactor name check and title update so works with custom prompt

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1129,7 +1129,7 @@ namespace Terminal {
             sw.add (term);
             var tab = new Granite.Widgets.Tab (label, icon, sw);
             term.tab = tab;
-            tab.ellipsize_mode = Pango.EllipsizeMode.START;
+            tab.ellipsize_mode = Pango.EllipsizeMode.MIDDLE;
 
             var reload_menu_item = new Gtk.MenuItem.with_label (_("Reload"));
             tab.menu.append (reload_menu_item);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -752,7 +752,6 @@ namespace Terminal {
 
         private bool on_close_tab_requested (Granite.Widgets.Tab tab) {
             var t = get_term_widget (tab);
-            bool closing_current_terminal = t == current_terminal;
 
             if (t.has_foreground_process ()) {
                 var d = new ForegroundProcessDialog (this);
@@ -775,7 +774,7 @@ namespace Terminal {
             }
 
             current_terminal.grab_focus ();
-            if (!closing_current_terminal) { // Otherwise current_terminal will change triggering a name check
+            if (t != current_terminal) { // Otherwise current_terminal will change triggering a name check
                 check_for_tabs_with_same_name ();
             }
 
@@ -795,6 +794,7 @@ namespace Terminal {
             notebook.insert_tab (tab, -1);
             notebook.current = tab;
             term.grab_focus ();
+            check_for_tabs_with_same_name ();
         }
 
         private void on_tab_moved (Granite.Widgets.Tab tab, int x, int y) {
@@ -958,8 +958,6 @@ namespace Terminal {
 
                 return false;
             });
-
-            check_for_tabs_with_same_name ();
         }
 
         private void open_tabs () {
@@ -1438,14 +1436,13 @@ namespace Terminal {
                     string term2_path = terminal2.current_working_directory;
                     string term2_name = Path.get_basename (term2_path);
 
-                    if (terminal2 != terminal && term2_name == term_label) {
-                        if (term2_path != term_path) {
-                            terminal2.tab_label = disambiguate_label (term2_path, term_path);
-                            terminal.tab_label = disambiguate_label (term_path, term2_path);
-                            // Overwrite tooltip_text set by changing tab_label
-                            terminal2.tooltip_text = term2_path;
-                            terminal.tooltip_text = term_path;
-                        }
+                    if (terminal2 != terminal && term2_name == term_label && term2_path != term_path) {
+                        terminal2.tab_label = disambiguate_label (term2_path, term_path);
+                        terminal.tab_label = disambiguate_label (term_path, term2_path);
+                        // Overwrite tooltip_text set by changing tab_label
+                        terminal2.tooltip_text = term2_path;
+                        terminal.tooltip_text = term_path;
+
                     }
                 }
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1418,7 +1418,7 @@ namespace Terminal {
             var terms2 = terminals.copy ();
 
             foreach (TerminalWidget terminal in terms) {
-                string term_path = terminal.get_shell_location ();
+                string term_path = terminal.current_working_directory;
                 string term_label = Path.get_basename (term_path);
 
                 if (term_label == "" ||
@@ -1431,7 +1431,7 @@ namespace Terminal {
                 terminal.tab_label = term_label;
 
                 foreach (TerminalWidget terminal2 in terms2) {
-                    string term2_path = terminal2.get_shell_location ();
+                    string term2_path = terminal2.current_working_directory;
                     string term2_name = Path.get_basename (term2_path);
 
                     if (terminal2 != terminal && term2_name == term_label) {
@@ -1445,7 +1445,7 @@ namespace Terminal {
                 terminal.tab.tooltip = term_path;
             }
 
-            title = current_terminal.get_shell_location ();
+            title = current_terminal.current_working_directory;
             return;
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -586,7 +586,6 @@ namespace Terminal {
                             get_simple_action (ACTION_COPY_LAST_OUTPUT).set_enabled (false);
                         }
 
-                        schedule_name_check (); // CWD may have changed
                         break;
 
                     case Gdk.Key.@1: //alt+[1-8]
@@ -1078,6 +1077,10 @@ namespace Terminal {
 
                     schedule_name_check ();
                 }
+            });
+
+            t.contents_changed.connect (() => {
+                schedule_name_check ();
             });
 
             t.set_font (term_font);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1074,9 +1074,7 @@ namespace Terminal {
                 }
             });
 
-            t.cwd_changed.connect (() => {
-                check_for_tabs_with_same_name ();
-            });
+            t.cwd_changed.connect (check_for_tabs_with_same_name);
 
             t.set_font (term_font);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -752,6 +752,7 @@ namespace Terminal {
 
         private bool on_close_tab_requested (Granite.Widgets.Tab tab) {
             var t = get_term_widget (tab);
+            bool closing_current_terminal = t == current_terminal;
 
             if (t.has_foreground_process ()) {
                 var d = new ForegroundProcessDialog (this);
@@ -774,6 +775,10 @@ namespace Terminal {
             }
 
             current_terminal.grab_focus ();
+            if (!closing_current_terminal) { // Otherwise current_terminal will change triggering a name check
+                check_for_tabs_with_same_name ();
+            }
+
             return true;
         }
 
@@ -1437,11 +1442,12 @@ namespace Terminal {
                         if (term2_path != term_path) {
                             terminal2.tab_label = disambiguate_label (term2_path, term_path);
                             terminal.tab_label = disambiguate_label (term_path, term2_path);
+                            // Overwrite tooltip_text set by changing tab_label
+                            terminal2.tooltip_text = term2_path;
+                            terminal.tooltip_text = term_path;
                         }
                     }
                 }
-
-                terminal.tab.tooltip = term_path;
             }
 
             title = current_terminal.current_working_directory;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -808,6 +808,7 @@ namespace Terminal {
                 notebook.remove_tab (tab);
                 new_notebook.insert_tab (tab, -1);
                 new_window.current_terminal = t;
+                check_for_tabs_with_same_name (); // Update remaining tabs
                 return false;
             });
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1290,7 +1290,6 @@ namespace Terminal {
         private void action_close_tab () {
             current_terminal.tab.close ();
             current_terminal.grab_focus ();
-            check_for_tabs_with_same_name ();
             // Closing a tab will switch to another, which will trigger check for same names
         }
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -336,7 +336,6 @@ namespace Terminal {
         void on_child_exited () {
             child_has_exited = true;
             last_key_was_return = true;
-            check_cwd_changed ();
         }
 
         public void kill_fg () {
@@ -616,7 +615,6 @@ namespace Terminal {
             Posix.kill (child_pid, Posix.Signal.TERM);
             reset (true, true);
             active_shell (old_loc);
-            check_cwd_changed ();
         }
 
         private void check_cwd_changed () {


### PR DESCRIPTION
Fixes #583 
Fixes #567 

Replaces #568 

* Run update on new tab, switch tab, close tab and contents changed
* Do not use terminal.window_title