### PR TITLE
Update window title on switch page

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -960,6 +960,7 @@ namespace Terminal {
             Idle.add (() => {
                 get_term_widget (new_tab).grab_focus ();
                 update_copy_output_sensitive ();
+                title = current_terminal.current_working_directory;
                 if (Granite.Services.System.history_is_enabled () &&
                     Application.settings.get_boolean ("remember-tabs")) {
 


### PR DESCRIPTION
Reinstate fix that was inadvertantly reverted in final version of c3e36fb2ab64c18028ff2b4a6da5bfb2171c1c04