### PR TITLE
Stop critical warnings on startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -490,7 +490,8 @@ namespace Terminal {
                 allow_restoring = Application.settings.get_boolean ("save-exited-tabs"),
                 max_restorable_tabs = 5,
                 group_name = "pantheon-terminal",
-                can_focus = false
+                can_focus = false,
+                expand = true
             };
             notebook.tab_added.connect (on_tab_added);
             notebook.tab_removed.connect (on_tab_removed);


### PR DESCRIPTION
This stops critical warnings like:
`(io.elementary.code:100977): Gtk-CRITICAL **: 13:21:33.248: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkNotebook` 
on startup