### PR TITLE
Save and restore last tab closed

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -757,10 +757,11 @@ namespace Terminal {
 
         private void on_tab_removed (Granite.Widgets.Tab tab) {
             var terminal_widget = get_term_widget (tab);
-            terminals.remove (terminal_widget);
-
             if (notebook.n_tabs == 0) {
+                save_opened_terminals ();
                 destroy ();
+            } else {
+                terminals.remove (terminal_widget);
             }
         }
 
@@ -1501,8 +1502,7 @@ namespace Terminal {
             if (Granite.Services.System.history_is_enabled () &&
                 Application.settings.get_boolean ("remember-tabs")) {
 
-                notebook.tabs.foreach ((tab) => {
-                    var term = get_term_widget (tab);
+                terminals.foreach ((term) => {
                     if (term != null) {
                         var location = term.get_shell_location ();
                         if (location != null && location != "") {
@@ -1525,7 +1525,7 @@ namespace Terminal {
 
             Terminal.Application.saved_state.set_int (
                 "focused-tab",
-                notebook.get_tab_position (notebook.current)
+                notebook.current != null ? notebook.get_tab_position (notebook.current) : 0
             );
         }
 


### PR DESCRIPTION
Fixes #603 

If closing a tab results in the window closing then the details of that tab (including zoom level) should be saved and restored.