### PR TITLE
MainWindow: Don't Close the Window During Drag and Drop

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -30,6 +30,7 @@ namespace Terminal {
 
         private HashTable<string, TerminalWidget> restorable_terminals;
         private bool is_fullscreen = false;
+        private bool on_drag = false;
         private string[] saved_tabs;
         private string[] saved_zooms;
 
@@ -501,6 +502,8 @@ namespace Terminal {
             notebook.tab_duplicated.connect (on_tab_duplicated);
             notebook.close_tab_requested.connect (on_close_tab_requested);
             notebook.new_tab_requested.connect (on_new_tab_requested);
+            notebook.get_child ().drag_begin.connect (on_drag_begin);
+            notebook.get_child ().drag_end.connect (on_drag_end);
             var tab_bar_behavior = Application.settings.get_enum ("tab-bar-behavior");
             notebook.tab_bar_behavior = (Granite.Widgets.DynamicNotebook.TabBarBehavior)tab_bar_behavior;
 
@@ -759,7 +762,7 @@ namespace Terminal {
             var terminal_widget = get_term_widget (tab);
             terminals.remove (terminal_widget);
 
-            if (notebook.n_tabs == 0) {
+            if (!on_drag && notebook.n_tabs == 0) {
                 destroy ();
             }
         }
@@ -842,6 +845,18 @@ namespace Terminal {
                 new_tab (current_terminal.get_shell_location ());
             } else {
                 new_tab (Environment.get_home_dir ());
+            }
+        }
+
+        private void on_drag_begin (Gdk.DragContext context) {
+            on_drag = true;
+        }
+
+        private void on_drag_end (Gdk.DragContext context) {
+            on_drag = false;
+
+            if (notebook.n_tabs == 0) {
+                destroy ();
             }
         }
 


### PR DESCRIPTION
When there's only one tab, dragging the tab out and back of the notebook area closes the window because of the check in `on_tab_removed`. Instead, only run the check if the function is not called during a drag and do it afterwards when the `drag_end` signal is emitted.

fixes #577.