### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/config.vala.in
+++ b/config.vala.in
@@ -1,4 +1,6 @@
 namespace Config {
     public const string PROJECT_NAME = @PROJECT_NAME@;
     public const string VERSION = @VERSION@;
+    public const string GETTEXT_PACKAGE = @GETTEXT_PACKAGE@;
+    public const string LOCALEDIR = @LOCALEDIR@;
 }

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,8 @@ terminal_resources = gnome.compile_resources(
 conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set_quoted('VERSION', meson.project_version())
+conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
+conf_data.set_quoted('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -53,6 +53,9 @@ public class Terminal.Application : Gtk.Application {
         application_id = "io.elementary.terminal";  /* Ensures only one instance runs */
 
         Intl.setlocale (LocaleCategory.ALL, "");
+        Intl.bindtextdomain (Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
+        Intl.bind_textdomain_codeset (Config.GETTEXT_PACKAGE, "UTF-8");
+        Intl.textdomain (Config.GETTEXT_PACKAGE);
     }
 
     public Application () {


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)