### PR TITLE
UnsafePasteDialog: use paste icon

### DIFF
--- a/src/Dialogs/UnsafePasteDialog.vala
+++ b/src/Dialogs/UnsafePasteDialog.vala
@@ -28,7 +28,8 @@ public class Terminal.UnsafePasteDialog : Granite.MessageDialog {
     }
 
     construct {
-        image_icon = new ThemedIcon ("dialog-warning");
+        image_icon = new ThemedIcon ("edit-paste");
+        badge_icon = new ThemedIcon ("dialog-warning");
 
         secondary_text =
             _("Copying commands into Terminal can be dangerous. Be sure you understand what each part of the pasted text does before continuing.");


### PR DESCRIPTION
Not 100% sure if this is better or worse, but figured I'd throw it out there:

## Before

![Screenshot from 2021-11-09 14 28 59](https://user-images.githubusercontent.com/7277719/141015890-2c568cb7-14d6-4fac-abf0-0fae228a37ee.png)

## AFTER

![Screenshot from 2021-11-09 14 28 36](https://user-images.githubusercontent.com/7277719/141015893-ae75824a-f514-49cd-a6cd-889f22363366.png)
