### PR TITLE
MainWindow: make tabs pinnable

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -492,6 +492,7 @@ namespace Terminal {
             ) {
                 allow_new_window = true,
                 allow_duplication = true,
+                allow_pinning = true,
                 allow_restoring = Application.settings.get_boolean ("save-exited-tabs"),
                 max_restorable_tabs = 5,
                 group_name = "pantheon-terminal",
@@ -978,8 +979,16 @@ namespace Terminal {
                                      Granite.Widgets.Tab new_tab) {
 
             current_terminal = get_term_widget (new_tab);
+
             /* The font-scales of all terminals are currently the synchronized through saved-state binding */
-            new_tab.icon = null;
+
+            // Switch from process-completed icon to pinned or blank depending on state of tab
+            if (new_tab.pinned) {
+                new_tab.icon = new ThemedIcon ("view-pin-symbolic");
+            } else {
+                new_tab.icon = null;
+            }
+
             Idle.add (() => {
                 get_term_widget (new_tab).grab_focus ();
                 update_copy_output_sensitive ();
@@ -1175,7 +1184,7 @@ namespace Terminal {
             });
             tab.ellipsize_mode = Pango.EllipsizeMode.MIDDLE;
 
-            /* Granite.Accel.from_action_name () does not allow control of which accel is used when 
+            /* Granite.Accel.from_action_name () does not allow control of which accel is used when
              * there are multiple so we have to use the other constructor to specify it. */
             var reload_menu_item = new Gtk.MenuItem () {
                 child = new Granite.AccelLabel (_("Reload"), ACTION_RELOAD_PREFERRED_ACCEL)
@@ -1183,6 +1192,14 @@ namespace Terminal {
             tab.menu.append (reload_menu_item);
             reload_menu_item.activate.connect (term.reload);
             tab.menu.show_all ();
+
+            tab.notify["pinned"].connect (() => {
+                if (tab.pinned) {
+                    tab.icon = new ThemedIcon ("view-pin-symbolic");
+                } else {
+                    tab.icon = null;
+                }
+            });
 
             return tab;
         }


### PR DESCRIPTION
Intended to fix #29. I actually came to file a similar issue to help me clean up my tab bar when I have a few long-running process, e.g. web servers, and found it was already reported. So far, this draft just makes tabs pinnable but does not prevent changes to the tabs themselves.

Icon-wise, I was looking for a `pinned` icon but found `changes-prevent` and `view-pin`. Neither seem like the perfect fit, but either might work fine. Open to feedback. I am seeing an issue where the icon is not centered in the pinned tab; not sure if I'm doing something wrong, or if this is a bug in Granite or the stylesheet.

![Screenshot from 2021-12-22 12 23 19](https://user-images.githubusercontent.com/611168/147144709-2a458d55-4aff-4ca5-be85-572479329e7d.png)

- [x] Make tabs pinnable
- [x] Update icons
- [ ] Prevent closing pinned tabs?
- [ ] Restore state of pinned tabs