### PR TITLE
Display character size on dragging window edges

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -521,7 +521,7 @@ namespace Terminal {
             var tab_bar_behavior = Application.settings.get_enum ("tab-bar-behavior");
             notebook.tab_bar_behavior = (Granite.Widgets.DynamicNotebook.TabBarBehavior)tab_bar_behavior;
 
-            size_label = new Gtk.Label();
+            size_label = new Gtk.Label("");
             size_label.set_valign(Gtk.Align.CENTER);
 
             size_revealer = new Gtk.Revealer ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -527,7 +527,6 @@ namespace Terminal {
             size_revealer = new Gtk.Revealer ();
             size_revealer.set_transition_type(Gtk.RevealerTransitionType.CROSSFADE);
             size_revealer.set_valign(Gtk.Align.CENTER);
-            size_revealer.hide();
             size_revealer.add (size_label);
 
             var overlay = new Gtk.Overlay();
@@ -1411,7 +1410,6 @@ namespace Terminal {
                 return true;
             });
 
-            size_revealer.show();
             size_revealer.set_reveal_child (true);
         }
 


### PR DESCRIPTION
Should resolve #443 

things to address upon : 

- At present, it connects the size-allocate signal of the grid to call the function to show size, this could probably be improved by connecting to some other signal 
- It shows the character size upon first launch
- Improve Design 
 