### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,7 +4,6 @@ install_data(
 )
 
 i18n.merge_file (
-    'desktop',
     input: meson.project_name() + '.desktop.in',
     output: meson.project_name() + '.desktop',
     install: true,
@@ -14,7 +13,6 @@ i18n.merge_file (
 )
 
 i18n.merge_file (
-    'desktop',
     input: 'open-pantheon-terminal-here.desktop.in',
     output: 'open-pantheon-terminal-here.desktop',
     install: true,
@@ -24,7 +22,6 @@ i18n.merge_file (
 )
 
 i18n.merge_file (
-    'appdata',
     input: meson.project_name() + '.appdata.xml.in',
     output: meson.project_name() + '.appdata.xml',
     install: true,


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.