### PR TITLE
MainWindow: Switch tab with Alt+[1-9] when there are at least 2 tabs

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -620,7 +620,8 @@ namespace Terminal {
                     case Gdk.Key.@7:
                     case Gdk.Key.@8:
                         if (Gdk.ModifierType.MOD1_MASK in event.state &&
-                            Application.settings.get_boolean ("alt-changes-tab")) {
+                            Application.settings.get_boolean ("alt-changes-tab") &&
+                            notebook.n_tabs > 1) {
                             var i = event.keyval - 49;
                             if (i > notebook.n_tabs - 1)
                                 return false;
@@ -630,7 +631,8 @@ namespace Terminal {
                         break;
                     case Gdk.Key.@9:
                         if (Gdk.ModifierType.MOD1_MASK in event.state &&
-                            Application.settings.get_boolean ("alt-changes-tab")) {
+                            Application.settings.get_boolean ("alt-changes-tab") &&
+                            notebook.n_tabs > 1) {
                             notebook.current = notebook.get_tab_by_index (notebook.n_tabs - 1);
                             return true;
                         }


### PR DESCRIPTION
This allows `Alt+[1-9]` to be handled by applications such as WeeChat (with just one tab open) while functioning like before when another is opened (previously `Alt+1` and `Alt+9` were completely unusable within WeeChat hindering its featureset).

Without more than one tab open it doesn't make sense attempting to handle the `Alt+1` and `Alt+9` shortcut actions anyway.