### PR TITLE
Add a custom theme dialog

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -50,3 +50,10 @@ vte-terminal {
     color: #000;
 }
 
+.color-custom radio {
+    -gtk-icon-source: -gtk-icontheme("list-add-symbolic");
+}
+
+.color-custom radio:checked {
+    -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
+}

--- a/meson.build
+++ b/meson.build
@@ -56,6 +56,7 @@ executable(
     'src/Themes.vala',
     'src/Dialogs/ForegroundProcessDialog.vala',
     'src/Dialogs/UnsafePasteDialog.vala',
+    'src/Dialogs/ColorPreferencesDialog.vala',
     'src/Widgets/SearchToolbar.vala',
     'src/Widgets/TerminalWidget.vala',
     'src/Utils.vala',

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -72,9 +72,9 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             margin_bottom = 12,
             tooltip_text = _("Reset to elementaryos default color palette")
         };
-        default_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
         default_button.clicked.connect (() => {
             Application.settings.set_string ("palette", string.joinv (":", HEX_PALETTE));
+            update_buttons_from_settings ();
         });
 
         var black_color_label = new SettingsLabel (_("Black:"));

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -1,0 +1,310 @@
+/*
+* Copyright (c) 2020 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 3, as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
+    private Gtk.ColorButton color01_button; // Black
+    private Gtk.ColorButton color02_button; // Red
+    private Gtk.ColorButton color03_button; // Green
+    private Gtk.ColorButton color04_button; // Yellow
+    private Gtk.ColorButton color05_button; // Blue
+    private Gtk.ColorButton color06_button; // Magenta
+    private Gtk.ColorButton color07_button; // Cyan
+    private Gtk.ColorButton color08_button; // Light gray
+    private Gtk.ColorButton color09_button; // Dark gray
+    private Gtk.ColorButton color10_button; // Light Red
+    private Gtk.ColorButton color11_button; // Light Green
+    private Gtk.ColorButton color12_button; // Light Yellow
+    private Gtk.ColorButton color13_button; // Light Blue
+    private Gtk.ColorButton color14_button; // Light Magenta
+    private Gtk.ColorButton color15_button; // Light Cyan
+    private Gtk.ColorButton color16_button; // White
+    private Gtk.ColorButton background_button;
+    private Gtk.ColorButton foreground_button;
+    private Gtk.ColorButton cursor_button;
+    private Gtk.Image contrast_image;
+
+    public ColorPreferences (Gtk.Window? parent) {
+        Object (
+            deletable: false,
+            resizable: false,
+            title: _("Color Preferences"),
+            transient_for: parent
+        );
+    }
+
+    construct {
+        var window_theme_label = new SettingsLabel (_("Window style:"));
+
+        var window_theme_switch = new Granite.ModeSwitch.from_icon_name (
+            "display-brightness-symbolic",
+            "weather-clear-night-symbolic"
+        ) {
+            primary_icon_tooltip_text = _("Light"),
+            secondary_icon_tooltip_text = _("Dark")
+        };
+        Application.settings.bind ("prefer-dark-style", window_theme_switch, "active", SettingsBindFlags.DEFAULT);
+
+        var black_color_label = new SettingsLabel (_("Black:"));
+        var red_color_label = new SettingsLabel (_("Red:"));
+        var green_color_label = new SettingsLabel (_("Green:"));
+        var yellow_color_label = new SettingsLabel (_("Yellow:"));
+        var blue_color_label = new SettingsLabel (_("Blue:"));
+        var magenta_color_label = new SettingsLabel (_("Magenta:"));
+        var cyan_color_label = new SettingsLabel (_("Cyan:"));
+        var grey_color_label = new SettingsLabel (_("Gray:"));
+        var background_label = new SettingsLabel (_("Background:"));
+        var foreground_label = new SettingsLabel (_("Foreground:"));
+        var cursor_label = new SettingsLabel (_("Cursor:"));
+
+        color01_button = new Gtk.ColorButton ();
+        color02_button = new Gtk.ColorButton ();
+        color03_button = new Gtk.ColorButton ();
+        color04_button = new Gtk.ColorButton ();
+        color05_button = new Gtk.ColorButton ();
+        color06_button = new Gtk.ColorButton ();
+        color07_button = new Gtk.ColorButton ();
+        color08_button = new Gtk.ColorButton ();
+        color09_button = new Gtk.ColorButton ();
+        color10_button = new Gtk.ColorButton ();
+        color11_button = new Gtk.ColorButton ();
+        color12_button = new Gtk.ColorButton ();
+        color13_button = new Gtk.ColorButton ();
+        color14_button = new Gtk.ColorButton ();
+        color15_button = new Gtk.ColorButton ();
+        color16_button = new Gtk.ColorButton ();
+        background_button = new Gtk.ColorButton () {
+            use_alpha = true
+        };
+        foreground_button = new Gtk.ColorButton ();
+        cursor_button = new Gtk.ColorButton () {
+            use_alpha = true
+        };
+
+        var contrast_top_label = new Gtk.Label ("┐");
+
+        contrast_image = new Gtk.Image.from_icon_name ("process-completed", Gtk.IconSize.LARGE_TOOLBAR);
+
+        var contrast_bottom_label = new Gtk.Label ("┘");
+
+        var contrast_grid = new Gtk.Grid () {
+            row_spacing = 3
+        };
+        contrast_grid.attach (contrast_top_label, 0, 0);
+        contrast_grid.attach (contrast_image, 0, 1);
+        contrast_grid.attach (contrast_bottom_label, 0, 2);
+
+        var colors_grid = new Gtk.Grid () {
+            column_spacing = 12,
+            row_spacing = 6,
+            margin_start = 12,
+            margin_end = 12,
+            halign = Gtk.Align.CENTER
+        };
+        colors_grid.attach (window_theme_label, 0, 0);
+        colors_grid.attach (window_theme_switch, 1, 0, 2);
+        colors_grid.attach (new Granite.HeaderLabel (_("Custom Colors")), 0, 3, 3);
+        colors_grid.attach (background_label, 0, 4, 1);
+        colors_grid.attach (background_button, 1, 4, 1);
+        colors_grid.attach (foreground_label, 0, 5, 1);
+        colors_grid.attach (foreground_button, 1, 5, 1);
+        colors_grid.attach (cursor_label, 0, 6, 1);
+        colors_grid.attach (cursor_button, 1, 6, 1);
+        colors_grid.attach (black_color_label, 0, 7, 1);
+        colors_grid.attach (color01_button, 1, 7, 1);
+        colors_grid.attach (color09_button, 2, 7, 1);
+        colors_grid.attach (red_color_label, 0, 8, 1);
+        colors_grid.attach (color02_button, 1, 8, 1);
+        colors_grid.attach (color10_button, 2, 8, 1);
+        colors_grid.attach (green_color_label, 0, 9, 1);
+        colors_grid.attach (color03_button, 1, 9, 1);
+        colors_grid.attach (color11_button, 2, 9, 1);
+        colors_grid.attach (yellow_color_label, 0, 10, 1);
+        colors_grid.attach (color04_button, 1, 10, 1);
+        colors_grid.attach (color12_button, 2, 10, 1);
+        colors_grid.attach (blue_color_label, 0, 11, 1);
+        colors_grid.attach (color05_button, 1, 11, 1);
+        colors_grid.attach (color13_button, 2, 11, 1);
+        colors_grid.attach (magenta_color_label, 0, 12, 1);
+        colors_grid.attach (color06_button, 1, 12, 1);
+        colors_grid.attach (color14_button, 2, 12, 1);
+        colors_grid.attach (cyan_color_label, 0, 13, 1);
+        colors_grid.attach (color07_button, 1, 13, 1);
+        colors_grid.attach (color15_button, 2, 13, 1);
+        colors_grid.attach (grey_color_label, 0, 14, 1);
+        colors_grid.attach (color08_button, 1, 14, 1);
+        colors_grid.attach (color16_button, 2, 14, 1);
+        colors_grid.attach (contrast_grid, 2, 4, 1, 2);
+
+        update_buttons_from_settings ();
+        update_contrast ();
+
+        get_content_area ().add (colors_grid);
+
+        var close_button = (Gtk.Button) add_button (_("Close"), Gtk.ResponseType.CLOSE);
+        close_button.clicked.connect (destroy);
+
+        Application.settings.set_string ("theme", Themes.CUSTOM);
+
+        color01_button.color_set.connect (update_palette_settings);
+        color02_button.color_set.connect (update_palette_settings);
+        color03_button.color_set.connect (update_palette_settings);
+        color04_button.color_set.connect (update_palette_settings);
+        color05_button.color_set.connect (update_palette_settings);
+        color06_button.color_set.connect (update_palette_settings);
+        color07_button.color_set.connect (update_palette_settings);
+        color08_button.color_set.connect (update_palette_settings);
+        color09_button.color_set.connect (update_palette_settings);
+        color10_button.color_set.connect (update_palette_settings);
+        color11_button.color_set.connect (update_palette_settings);
+        color12_button.color_set.connect (update_palette_settings);
+        color13_button.color_set.connect (update_palette_settings);
+        color14_button.color_set.connect (update_palette_settings);
+        color15_button.color_set.connect (update_palette_settings);
+        color16_button.color_set.connect (update_palette_settings);
+
+        background_button.color_set.connect (() => {
+            Application.settings.set_string ("background", background_button.rgba.to_string ());
+            update_contrast ();
+        });
+
+        foreground_button.color_set.connect (() => {
+            Application.settings.set_string ("foreground", foreground_button.rgba.to_string ());
+            update_contrast ();
+        });
+
+        cursor_button.color_set.connect (() => {
+            Application.settings.set_string ("cursor-color", cursor_button.rgba.to_string ());
+        });
+    }
+
+    private void update_palette_settings () {
+        string[] colors = {
+            color01_button.rgba.to_string (),
+            color02_button.rgba.to_string (),
+            color03_button.rgba.to_string (),
+            color04_button.rgba.to_string (),
+            color05_button.rgba.to_string (),
+            color06_button.rgba.to_string (),
+            color07_button.rgba.to_string (),
+            color08_button.rgba.to_string (),
+            color09_button.rgba.to_string (),
+            color10_button.rgba.to_string (),
+            color11_button.rgba.to_string (),
+            color12_button.rgba.to_string (),
+            color13_button.rgba.to_string (),
+            color14_button.rgba.to_string (),
+            color15_button.rgba.to_string (),
+            color16_button.rgba.to_string ()
+        };
+
+        Application.settings.set_string ("palette", string.joinv (":", colors));
+    }
+
+    private void update_buttons_from_settings () {
+        var color_palette = new Gdk.RGBA[Terminal.Themes.PALETTE_SIZE];
+
+        var palette = Application.settings.get_string ("palette");
+        var background = Application.settings.get_string ("background");
+        var foreground = Application.settings.get_string ("foreground");
+        var cursor = Application.settings.get_string ("cursor-color");
+
+        var input_palette = @"$palette:$background:$foreground:$cursor".split (":");
+
+        for (int i = 0; i < input_palette.length; i++) {
+            if (!color_palette[i].parse (input_palette[i])) {
+                warning ("Found invalid color in one of the color palette settings");
+                return;
+            }
+        }
+
+        color01_button.rgba = color_palette[0];
+        color02_button.rgba = color_palette[1];
+        color03_button.rgba = color_palette[2];
+        color04_button.rgba = color_palette[3];
+        color05_button.rgba = color_palette[4];
+        color06_button.rgba = color_palette[5];
+        color07_button.rgba = color_palette[6];
+        color08_button.rgba = color_palette[7];
+        color09_button.rgba = color_palette[8];
+        color10_button.rgba = color_palette[9];
+        color11_button.rgba = color_palette[10];
+        color12_button.rgba = color_palette[11];
+        color13_button.rgba = color_palette[12];
+        color14_button.rgba = color_palette[13];
+        color15_button.rgba = color_palette[14];
+        color16_button.rgba = color_palette[15];
+
+        background_button.rgba = color_palette[16];
+        foreground_button.rgba = color_palette[17];
+        cursor_button.rgba = color_palette[18];
+    }
+
+    private void update_contrast () {
+        var contrast_ratio = get_contrast_ratio (foreground_button.rgba, background_button.rgba);
+        if (contrast_ratio < 3) {
+            contrast_image.icon_name = "dialog-warning";
+            contrast_image.tooltip_text = _("Contrast is very low");
+        } else if (contrast_ratio < 4.5) {
+            contrast_image.icon_name = "dialog-warning";
+            contrast_image.tooltip_text = _("Contrast is low");
+        } else if (contrast_ratio < 7) {
+            contrast_image.icon_name = "process-completed";
+            contrast_image.tooltip_text = _("Contrast is good");
+        } else {
+            contrast_image.icon_name = "process-completed";
+            contrast_image.tooltip_text = _("Contrast is high");
+        }
+    }
+
+    // contrast ratio code is taken from https://github.com/danrabbit/harvey/
+    private double get_contrast_ratio (Gdk.RGBA foreground, Gdk.RGBA background) {
+        var foreground_luminance = get_luminance (foreground);
+        var background_luminance = get_luminance (background);
+
+        if (background_luminance > foreground_luminance) {
+            return (background_luminance + 0.05) / (foreground_luminance + 0.05);
+        } else {
+            return (foreground_luminance + 0.05) / (background_luminance + 0.05);
+        }
+    }
+
+    private double get_luminance (Gdk.RGBA color) {
+        var red = sanitize_color (color.red) * 0.2126;
+        var green = sanitize_color (color.green) * 0.7152;
+        var blue = sanitize_color (color.blue) * 0.0722;
+
+        return (red + green + blue);
+    }
+
+    private double sanitize_color (double color) {
+        if (color <= 0.03928) {
+            color = color / 12.92;
+        } else {
+            color = Math.pow ((color + 0.055) / 1.055, 2.4);
+        }
+        return color;
+    }
+
+    private class SettingsLabel : Gtk.Label {
+        public SettingsLabel (string text) {
+            label = text;
+            halign = Gtk.Align.END;
+            margin_start = 12;
+        }
+    }
+}

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -47,7 +47,9 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
     }
 
     construct {
-        var window_theme_label = new SettingsLabel (_("Window style:"));
+        var window_theme_label = new SettingsLabel (_("Window style:")) {
+            margin_bottom = 12
+        };
 
         var window_theme_switch = new Granite.ModeSwitch.from_icon_name (
             "display-brightness-symbolic",
@@ -57,15 +59,24 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             secondary_icon_tooltip_text = _("Dark")
         };
         Application.settings.bind ("prefer-dark-style", window_theme_switch, "active", SettingsBindFlags.DEFAULT);
-        var window_theme_grid = new Gtk.Grid () {
-            column_spacing = 12,
-            row_spacing = 6,
-            margin_start = 12,
-            margin_end = 12,
-            halign = Gtk.Align.CENTER
+
+        var palette_header = new Gtk.Label (_("Color Palette")) {
+            margin_top = 12,
+            margin_bottom = 12
         };
-        window_theme_grid.attach (window_theme_label, 0, 0);
-        window_theme_grid.attach (window_theme_switch, 2, 0, 2);
+        palette_header.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
+
+        var default_button = new Gtk.Button.from_icon_name ("edit-clear-all-symbolic") {
+            halign = Gtk.Align.END,
+            margin_top = 12,
+            margin_bottom = 12,
+            tooltip_text = _("Reset to elementaryos default color palette")
+        };
+        default_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        default_button.clicked.connect (() => {
+            Application.settings.set_string ("palette", string.joinv (":", HEX_PALETTE));
+        });
+
         var black_color_label = new SettingsLabel (_("Black:"));
         var red_color_label = new SettingsLabel (_("Red:"));
         var green_color_label = new SettingsLabel (_("Green:"));
@@ -124,54 +135,60 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         var colors_grid = new Gtk.Grid () {
             column_spacing = 12,
             row_spacing = 6,
+            margin_top = 12,
+            margin_bottom = 12,
             margin_start = 12,
             margin_end = 12,
             halign = Gtk.Align.CENTER
         };
+
+        colors_grid.attach (window_theme_label, 0, 1);
+        colors_grid.attach (window_theme_switch, 1, 1, 2);
         colors_grid.attach (background_label, 0, 4, 1);
         colors_grid.attach (background_button, 1, 4, 1);
         colors_grid.attach (foreground_label, 0, 5, 1);
         colors_grid.attach (foreground_button, 1, 5, 1);
+        colors_grid.attach (contrast_grid, 2, 4, 1, 2);
         colors_grid.attach (cursor_label, 0, 6, 1);
         colors_grid.attach (cursor_button, 1, 6, 1);
-        colors_grid.attach (black_color_label, 0, 7, 1);
-        colors_grid.attach (black_button, 1, 7, 1);
-        colors_grid.attach (dark_gray_color_label, 2, 7, 1);
-        colors_grid.attach (dark_gray_button, 3, 7, 1);
-        colors_grid.attach (red_color_label, 0, 8, 1);
-        colors_grid.attach (red_button, 1, 8, 1);
-        colors_grid.attach (light_red_color_label, 2, 8, 1);
-        colors_grid.attach (light_red_button, 3, 8, 1);
-        colors_grid.attach (green_color_label, 0, 9, 1);
-        colors_grid.attach (green_button, 1, 9, 1);
-        colors_grid.attach (light_green_color_label, 2, 9, 1);
-        colors_grid.attach (light_green_button, 3, 9, 1);
-        colors_grid.attach (yellow_color_label, 0, 10, 1);
-        colors_grid.attach (yellow_button, 1, 10, 1);
-        colors_grid.attach (light_yellow_color_label, 2, 10, 1);
-        colors_grid.attach (light_yellow_button, 3, 10, 1);
-        colors_grid.attach (blue_color_label, 0, 11, 1);
-        colors_grid.attach (blue_button, 1, 11, 1);
-        colors_grid.attach (light_blue_color_label, 2, 11, 1);
-        colors_grid.attach (light_blue_button, 3, 11, 1);
-        colors_grid.attach (magenta_color_label, 0, 12, 1);
-        colors_grid.attach (magenta_button, 1, 12, 1);
-        colors_grid.attach (light_magenta_color_label, 2, 12, 1);
-        colors_grid.attach (light_magenta_button, 3, 12, 1);
-        colors_grid.attach (cyan_color_label, 0, 13, 1);
-        colors_grid.attach (cyan_button, 1, 13, 1);
-        colors_grid.attach (light_cyan_color_label, 2, 13, 1);
-        colors_grid.attach (light_cyan_button, 3, 13, 1);
-        colors_grid.attach (light_gray_color_label, 0, 14, 1);
-        colors_grid.attach (light_gray_button, 1, 14, 1);
-        colors_grid.attach (white_color_label, 2, 14, 1);
-        colors_grid.attach (white_button, 3, 14, 1);
-        colors_grid.attach (contrast_grid, 2, 4, 1, 2);
+        colors_grid.attach (palette_header, 0, 7, 1);
+        colors_grid.attach (default_button, 3, 7, 1);
+        colors_grid.attach (black_color_label, 0, 8, 1);
+        colors_grid.attach (black_button, 1, 8, 1);
+        colors_grid.attach (dark_gray_color_label, 2, 8, 1);
+        colors_grid.attach (dark_gray_button, 3, 8, 1);
+        colors_grid.attach (red_color_label, 0, 9, 1);
+        colors_grid.attach (red_button, 1, 9, 1);
+        colors_grid.attach (light_red_color_label, 2, 9, 1);
+        colors_grid.attach (light_red_button, 3, 9, 1);
+        colors_grid.attach (green_color_label, 0, 10, 1);
+        colors_grid.attach (green_button, 1, 10, 1);
+        colors_grid.attach (light_green_color_label, 2, 10, 1);
+        colors_grid.attach (light_green_button, 3, 10, 1);
+        colors_grid.attach (yellow_color_label, 0, 11, 1);
+        colors_grid.attach (yellow_button, 1, 11, 1);
+        colors_grid.attach (light_yellow_color_label, 2, 11, 1);
+        colors_grid.attach (light_yellow_button, 3, 11, 1);
+        colors_grid.attach (blue_color_label, 0, 12, 1);
+        colors_grid.attach (blue_button, 1, 12, 1);
+        colors_grid.attach (light_blue_color_label, 2, 12, 1);
+        colors_grid.attach (light_blue_button, 3, 12, 1);
+        colors_grid.attach (magenta_color_label, 0, 13, 1);
+        colors_grid.attach (magenta_button, 1, 13, 1);
+        colors_grid.attach (light_magenta_color_label, 2, 13, 1);
+        colors_grid.attach (light_magenta_button, 3, 13, 1);
+        colors_grid.attach (cyan_color_label, 0, 14, 1);
+        colors_grid.attach (cyan_button, 1, 14, 1);
+        colors_grid.attach (light_cyan_color_label, 2, 14, 1);
+        colors_grid.attach (light_cyan_button, 3, 14, 1);
+        colors_grid.attach (light_gray_color_label, 0, 15, 1);
+        colors_grid.attach (light_gray_button, 1, 15, 1);
+        colors_grid.attach (white_color_label, 2, 15, 1);
+        colors_grid.attach (white_button, 3, 15, 1);
 
         update_buttons_from_settings ();
         update_contrast (contrast_image);
 
-        get_content_area ().add (window_theme_grid);
         get_content_area ().add (colors_grid);
 
         var close_button = (Gtk.Button) add_button (_("Close"), Gtk.ResponseType.CLOSE);

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright (c) 2020 elementary, Inc. (https://elementary.io)
+* Copyright 2022 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU Lesser General Public

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -17,22 +17,22 @@
 */
 
 public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
-    private Gtk.ColorButton color01_button; // Black
-    private Gtk.ColorButton color02_button; // Red
-    private Gtk.ColorButton color03_button; // Green
-    private Gtk.ColorButton color04_button; // Yellow
-    private Gtk.ColorButton color05_button; // Blue
-    private Gtk.ColorButton color06_button; // Magenta
-    private Gtk.ColorButton color07_button; // Cyan
-    private Gtk.ColorButton color08_button; // Light gray
-    private Gtk.ColorButton color09_button; // Dark gray
-    private Gtk.ColorButton color10_button; // Light Red
-    private Gtk.ColorButton color11_button; // Light Green
-    private Gtk.ColorButton color12_button; // Light Yellow
-    private Gtk.ColorButton color13_button; // Light Blue
-    private Gtk.ColorButton color14_button; // Light Magenta
-    private Gtk.ColorButton color15_button; // Light Cyan
-    private Gtk.ColorButton color16_button; // White
+    private Gtk.ColorButton black_button;
+    private Gtk.ColorButton red_button;
+    private Gtk.ColorButton green_button;
+    private Gtk.ColorButton yellow_button;
+    private Gtk.ColorButton blue_button;
+    private Gtk.ColorButton magenta_button;
+    private Gtk.ColorButton cyan_button;
+    private Gtk.ColorButton light_gray_button;
+    private Gtk.ColorButton dark_gray_button;
+    private Gtk.ColorButton light_red_button;
+    private Gtk.ColorButton light_green_button;
+    private Gtk.ColorButton light_yellow_button;
+    private Gtk.ColorButton light_blue_button;
+    private Gtk.ColorButton light_magenta_button;
+    private Gtk.ColorButton light_cyan_button;
+    private Gtk.ColorButton white_button;
     private Gtk.ColorButton background_button;
     private Gtk.ColorButton foreground_button;
     private Gtk.ColorButton cursor_button;
@@ -57,7 +57,15 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             secondary_icon_tooltip_text = _("Dark")
         };
         Application.settings.bind ("prefer-dark-style", window_theme_switch, "active", SettingsBindFlags.DEFAULT);
-
+        var window_theme_grid = new Gtk.Grid () {
+            column_spacing = 12,
+            row_spacing = 6,
+            margin_start = 12,
+            margin_end = 12,
+            halign = Gtk.Align.CENTER
+        };
+        window_theme_grid.attach (window_theme_label, 0, 0);
+        window_theme_grid.attach (window_theme_switch, 2, 0, 2);
         var black_color_label = new SettingsLabel (_("Black:"));
         var red_color_label = new SettingsLabel (_("Red:"));
         var green_color_label = new SettingsLabel (_("Green:"));
@@ -65,27 +73,35 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         var blue_color_label = new SettingsLabel (_("Blue:"));
         var magenta_color_label = new SettingsLabel (_("Magenta:"));
         var cyan_color_label = new SettingsLabel (_("Cyan:"));
-        var grey_color_label = new SettingsLabel (_("Gray:"));
+        var dark_gray_color_label = new SettingsLabel (_("Gray:"));
+        var white_color_label = new SettingsLabel (_("White:"));
+        var light_red_color_label = new SettingsLabel (_("Light Red:"));
+        var light_green_color_label = new SettingsLabel (_("Light Green:"));
+        var light_yellow_color_label = new SettingsLabel (_("Light Yellow:"));
+        var light_blue_color_label = new SettingsLabel (_("Light Blue:"));
+        var light_magenta_color_label = new SettingsLabel (_("Light Magenta:"));
+        var light_cyan_color_label = new SettingsLabel (_("Light Cyan:"));
+        var light_gray_color_label = new SettingsLabel (_("Light Gray:"));
         var background_label = new SettingsLabel (_("Background:"));
         var foreground_label = new SettingsLabel (_("Foreground:"));
         var cursor_label = new SettingsLabel (_("Cursor:"));
 
-        color01_button = new Gtk.ColorButton ();
-        color02_button = new Gtk.ColorButton ();
-        color03_button = new Gtk.ColorButton ();
-        color04_button = new Gtk.ColorButton ();
-        color05_button = new Gtk.ColorButton ();
-        color06_button = new Gtk.ColorButton ();
-        color07_button = new Gtk.ColorButton ();
-        color08_button = new Gtk.ColorButton ();
-        color09_button = new Gtk.ColorButton ();
-        color10_button = new Gtk.ColorButton ();
-        color11_button = new Gtk.ColorButton ();
-        color12_button = new Gtk.ColorButton ();
-        color13_button = new Gtk.ColorButton ();
-        color14_button = new Gtk.ColorButton ();
-        color15_button = new Gtk.ColorButton ();
-        color16_button = new Gtk.ColorButton ();
+        black_button = new Gtk.ColorButton ();
+        red_button = new Gtk.ColorButton ();
+        green_button = new Gtk.ColorButton ();
+        yellow_button = new Gtk.ColorButton ();
+        blue_button = new Gtk.ColorButton ();
+        magenta_button = new Gtk.ColorButton ();
+        cyan_button = new Gtk.ColorButton ();
+        light_gray_button = new Gtk.ColorButton ();
+        dark_gray_button = new Gtk.ColorButton ();
+        light_red_button = new Gtk.ColorButton ();
+        light_green_button = new Gtk.ColorButton ();
+        light_yellow_button = new Gtk.ColorButton ();
+        light_blue_button = new Gtk.ColorButton ();
+        light_magenta_button = new Gtk.ColorButton ();
+        light_cyan_button = new Gtk.ColorButton ();
+        white_button = new Gtk.ColorButton ();
         background_button = new Gtk.ColorButton () {
             use_alpha = true
         };
@@ -112,9 +128,6 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             margin_end = 12,
             halign = Gtk.Align.CENTER
         };
-        colors_grid.attach (window_theme_label, 0, 0);
-        colors_grid.attach (window_theme_switch, 1, 0, 2);
-        colors_grid.attach (new Granite.HeaderLabel (_("Custom Colors")), 0, 3, 3);
         colors_grid.attach (background_label, 0, 4, 1);
         colors_grid.attach (background_button, 1, 4, 1);
         colors_grid.attach (foreground_label, 0, 5, 1);
@@ -122,34 +135,43 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         colors_grid.attach (cursor_label, 0, 6, 1);
         colors_grid.attach (cursor_button, 1, 6, 1);
         colors_grid.attach (black_color_label, 0, 7, 1);
-        colors_grid.attach (color01_button, 1, 7, 1);
-        colors_grid.attach (color09_button, 2, 7, 1);
+        colors_grid.attach (black_button, 1, 7, 1);
+        colors_grid.attach (dark_gray_color_label, 2, 7, 1);
+        colors_grid.attach (dark_gray_button, 3, 7, 1);
         colors_grid.attach (red_color_label, 0, 8, 1);
-        colors_grid.attach (color02_button, 1, 8, 1);
-        colors_grid.attach (color10_button, 2, 8, 1);
+        colors_grid.attach (red_button, 1, 8, 1);
+        colors_grid.attach (light_red_color_label, 2, 8, 1);
+        colors_grid.attach (light_red_button, 3, 8, 1);
         colors_grid.attach (green_color_label, 0, 9, 1);
-        colors_grid.attach (color03_button, 1, 9, 1);
-        colors_grid.attach (color11_button, 2, 9, 1);
+        colors_grid.attach (green_button, 1, 9, 1);
+        colors_grid.attach (light_green_color_label, 2, 9, 1);
+        colors_grid.attach (light_green_button, 3, 9, 1);
         colors_grid.attach (yellow_color_label, 0, 10, 1);
-        colors_grid.attach (color04_button, 1, 10, 1);
-        colors_grid.attach (color12_button, 2, 10, 1);
+        colors_grid.attach (yellow_button, 1, 10, 1);
+        colors_grid.attach (light_yellow_color_label, 2, 10, 1);
+        colors_grid.attach (light_yellow_button, 3, 10, 1);
         colors_grid.attach (blue_color_label, 0, 11, 1);
-        colors_grid.attach (color05_button, 1, 11, 1);
-        colors_grid.attach (color13_button, 2, 11, 1);
+        colors_grid.attach (blue_button, 1, 11, 1);
+        colors_grid.attach (light_blue_color_label, 2, 11, 1);
+        colors_grid.attach (light_blue_button, 3, 11, 1);
         colors_grid.attach (magenta_color_label, 0, 12, 1);
-        colors_grid.attach (color06_button, 1, 12, 1);
-        colors_grid.attach (color14_button, 2, 12, 1);
+        colors_grid.attach (magenta_button, 1, 12, 1);
+        colors_grid.attach (light_magenta_color_label, 2, 12, 1);
+        colors_grid.attach (light_magenta_button, 3, 12, 1);
         colors_grid.attach (cyan_color_label, 0, 13, 1);
-        colors_grid.attach (color07_button, 1, 13, 1);
-        colors_grid.attach (color15_button, 2, 13, 1);
-        colors_grid.attach (grey_color_label, 0, 14, 1);
-        colors_grid.attach (color08_button, 1, 14, 1);
-        colors_grid.attach (color16_button, 2, 14, 1);
+        colors_grid.attach (cyan_button, 1, 13, 1);
+        colors_grid.attach (light_cyan_color_label, 2, 13, 1);
+        colors_grid.attach (light_cyan_button, 3, 13, 1);
+        colors_grid.attach (light_gray_color_label, 0, 14, 1);
+        colors_grid.attach (light_gray_button, 1, 14, 1);
+        colors_grid.attach (white_color_label, 2, 14, 1);
+        colors_grid.attach (white_button, 3, 14, 1);
         colors_grid.attach (contrast_grid, 2, 4, 1, 2);
 
         update_buttons_from_settings ();
         update_contrast (contrast_image);
 
+        get_content_area ().add (window_theme_grid);
         get_content_area ().add (colors_grid);
 
         var close_button = (Gtk.Button) add_button (_("Close"), Gtk.ResponseType.CLOSE);
@@ -157,22 +179,22 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
 
         Application.settings.set_string ("theme", Themes.CUSTOM);
 
-        color01_button.color_set.connect (update_palette_settings);
-        color02_button.color_set.connect (update_palette_settings);
-        color03_button.color_set.connect (update_palette_settings);
-        color04_button.color_set.connect (update_palette_settings);
-        color05_button.color_set.connect (update_palette_settings);
-        color06_button.color_set.connect (update_palette_settings);
-        color07_button.color_set.connect (update_palette_settings);
-        color08_button.color_set.connect (update_palette_settings);
-        color09_button.color_set.connect (update_palette_settings);
-        color10_button.color_set.connect (update_palette_settings);
-        color11_button.color_set.connect (update_palette_settings);
-        color12_button.color_set.connect (update_palette_settings);
-        color13_button.color_set.connect (update_palette_settings);
-        color14_button.color_set.connect (update_palette_settings);
-        color15_button.color_set.connect (update_palette_settings);
-        color16_button.color_set.connect (update_palette_settings);
+        black_button.color_set.connect (update_palette_settings);
+        red_button.color_set.connect (update_palette_settings);
+        green_button.color_set.connect (update_palette_settings);
+        yellow_button.color_set.connect (update_palette_settings);
+        blue_button.color_set.connect (update_palette_settings);
+        magenta_button.color_set.connect (update_palette_settings);
+        cyan_button.color_set.connect (update_palette_settings);
+        light_gray_button.color_set.connect (update_palette_settings);
+        dark_gray_button.color_set.connect (update_palette_settings);
+        light_red_button.color_set.connect (update_palette_settings);
+        light_green_button.color_set.connect (update_palette_settings);
+        light_yellow_button.color_set.connect (update_palette_settings);
+        light_blue_button.color_set.connect (update_palette_settings);
+        light_magenta_button.color_set.connect (update_palette_settings);
+        light_cyan_button.color_set.connect (update_palette_settings);
+        white_button.color_set.connect (update_palette_settings);
 
         background_button.color_set.connect (() => {
             Application.settings.set_string ("background", background_button.rgba.to_string ());
@@ -197,22 +219,22 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
 
     private void update_palette_settings () {
         string[] colors = {
-            color01_button.rgba.to_string (),
-            color02_button.rgba.to_string (),
-            color03_button.rgba.to_string (),
-            color04_button.rgba.to_string (),
-            color05_button.rgba.to_string (),
-            color06_button.rgba.to_string (),
-            color07_button.rgba.to_string (),
-            color08_button.rgba.to_string (),
-            color09_button.rgba.to_string (),
-            color10_button.rgba.to_string (),
-            color11_button.rgba.to_string (),
-            color12_button.rgba.to_string (),
-            color13_button.rgba.to_string (),
-            color14_button.rgba.to_string (),
-            color15_button.rgba.to_string (),
-            color16_button.rgba.to_string ()
+            black_button.rgba.to_string (),
+            red_button.rgba.to_string (),
+            green_button.rgba.to_string (),
+            yellow_button.rgba.to_string (),
+            blue_button.rgba.to_string (),
+            magenta_button.rgba.to_string (),
+            cyan_button.rgba.to_string (),
+            light_gray_button.rgba.to_string (),
+            dark_gray_button.rgba.to_string (),
+            light_red_button.rgba.to_string (),
+            light_green_button.rgba.to_string (),
+            light_yellow_button.rgba.to_string (),
+            light_blue_button.rgba.to_string (),
+            light_magenta_button.rgba.to_string (),
+            light_cyan_button.rgba.to_string (),
+            white_button.rgba.to_string ()
         };
 
         Application.settings.set_string ("palette", string.joinv (":", colors));
@@ -235,22 +257,22 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             }
         }
 
-        color01_button.rgba = color_palette[0];
-        color02_button.rgba = color_palette[1];
-        color03_button.rgba = color_palette[2];
-        color04_button.rgba = color_palette[3];
-        color05_button.rgba = color_palette[4];
-        color06_button.rgba = color_palette[5];
-        color07_button.rgba = color_palette[6];
-        color08_button.rgba = color_palette[7];
-        color09_button.rgba = color_palette[8];
-        color10_button.rgba = color_palette[9];
-        color11_button.rgba = color_palette[10];
-        color12_button.rgba = color_palette[11];
-        color13_button.rgba = color_palette[12];
-        color14_button.rgba = color_palette[13];
-        color15_button.rgba = color_palette[14];
-        color16_button.rgba = color_palette[15];
+        black_button.rgba = color_palette[0];
+        red_button.rgba = color_palette[1];
+        green_button.rgba = color_palette[2];
+        yellow_button.rgba = color_palette[3];
+        blue_button.rgba = color_palette[4];
+        magenta_button.rgba = color_palette[5];
+        cyan_button.rgba = color_palette[6];
+        light_gray_button.rgba = color_palette[7];
+        dark_gray_button.rgba = color_palette[8];
+        light_red_button.rgba = color_palette[9];
+        light_green_button.rgba = color_palette[10];
+        light_yellow_button.rgba = color_palette[11];
+        light_blue_button.rgba = color_palette[12];
+        light_magenta_button.rgba = color_palette[13];
+        light_cyan_button.rgba = color_palette[14];
+        white_button.rgba = color_palette[15];
 
         background_button.rgba = color_palette[16];
         foreground_button.rgba = color_palette[17];

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -36,7 +36,6 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
     private Gtk.ColorButton background_button;
     private Gtk.ColorButton foreground_button;
     private Gtk.ColorButton cursor_button;
-    private Gtk.Image contrast_image;
 
     public ColorPreferences (Gtk.Window? parent) {
         Object (
@@ -95,11 +94,9 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
             use_alpha = true
         };
 
-        var contrast_top_label = new Gtk.Label ("┐");
-
-        contrast_image = new Gtk.Image.from_icon_name ("process-completed", Gtk.IconSize.LARGE_TOOLBAR);
-
-        var contrast_bottom_label = new Gtk.Label ("┘");
+        var contrast_top_label = new Gtk.Label (""); // Text will be set on showing
+        var contrast_bottom_label = new Gtk.Label (""); // Text will be set on showing
+        var contrast_image = new Gtk.Image.from_icon_name ("process-completed", Gtk.IconSize.LARGE_TOOLBAR);
 
         var contrast_grid = new Gtk.Grid () {
             row_spacing = 3
@@ -151,7 +148,7 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         colors_grid.attach (contrast_grid, 2, 4, 1, 2);
 
         update_buttons_from_settings ();
-        update_contrast ();
+        update_contrast (contrast_image);
 
         get_content_area ().add (colors_grid);
 
@@ -179,16 +176,22 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
 
         background_button.color_set.connect (() => {
             Application.settings.set_string ("background", background_button.rgba.to_string ());
-            update_contrast ();
+            update_contrast (contrast_image);
         });
 
         foreground_button.color_set.connect (() => {
             Application.settings.set_string ("foreground", foreground_button.rgba.to_string ());
-            update_contrast ();
+            update_contrast (contrast_image);
         });
 
         cursor_button.color_set.connect (() => {
             Application.settings.set_string ("cursor-color", cursor_button.rgba.to_string ());
+        });
+
+        contrast_top_label.state_flags_changed.connect ((previous_flags) => {
+            var state_flags = get_state_flags ();
+            contrast_top_label.label = Gtk.StateFlags.DIR_LTR in state_flags ? "┐" : "┌";
+            contrast_bottom_label.label = Gtk.StateFlags.DIR_LTR in state_flags ? "┘" : "└";
         });
     }
 
@@ -254,7 +257,7 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         cursor_button.rgba = color_palette[18];
     }
 
-    private void update_contrast () {
+    private void update_contrast (Gtk.Image contrast_image) {
         var contrast_ratio = get_contrast_ratio (foreground_button.rgba, background_button.rgba);
         if (contrast_ratio < 3) {
             contrast_image.icon_name = "dialog-warning";

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -69,7 +69,7 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         var default_button = new Gtk.Button.from_icon_name ("edit-clear-all-symbolic") {
             halign = Gtk.Align.END,
             margin_top = 12,
-            margin_bottom = 12,
+            margin_bottom = 6,
             tooltip_text = _("Reset to elementaryos default color palette")
         };
         default_button.clicked.connect (() => {
@@ -144,6 +144,8 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
 
         colors_grid.attach (window_theme_label, 0, 1);
         colors_grid.attach (window_theme_switch, 1, 1, 2);
+        colors_grid.attach (palette_header, 0, 2, 1);
+        colors_grid.attach (default_button, 3, 2, 1);
         colors_grid.attach (background_label, 0, 4, 1);
         colors_grid.attach (background_button, 1, 4, 1);
         colors_grid.attach (foreground_label, 0, 5, 1);
@@ -151,8 +153,7 @@ public class Terminal.Dialogs.ColorPreferences : Gtk.Dialog {
         colors_grid.attach (contrast_grid, 2, 4, 1, 2);
         colors_grid.attach (cursor_label, 0, 6, 1);
         colors_grid.attach (cursor_button, 1, 6, 1);
-        colors_grid.attach (palette_header, 0, 7, 1);
-        colors_grid.attach (default_button, 3, 7, 1);
+
         colors_grid.attach (black_color_label, 0, 8, 1);
         colors_grid.attach (black_button, 1, 8, 1);
         colors_grid.attach (dark_gray_color_label, 2, 8, 1);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -26,6 +26,7 @@ namespace Terminal {
         private Gtk.Revealer search_revealer;
         private Gtk.ToggleButton search_button;
         private Gtk.Button zoom_default_button;
+        private Dialogs.ColorPreferences? color_preferences_dialog;
         private Granite.AccelLabel open_in_browser_menuitem_label;
 
         private HashTable<string, TerminalWidget> restorable_terminals;
@@ -421,6 +422,15 @@ namespace Terminal {
             color_button_dark_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
             color_button_dark_context.add_class ("color-dark");
 
+            var color_button_custom = new Gtk.RadioButton.from_widget (color_button_white) {
+                halign = Gtk.Align.CENTER,
+                tooltip_text = _("Custom")
+            };
+
+            unowned Gtk.StyleContext color_button_custom_context = color_button_custom.get_style_context ();
+            color_button_custom_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
+            color_button_custom_context.add_class ("color-custom");
+
             var color_grid = new Gtk.Grid () {
                 column_homogeneous = true,
                 margin_start = 12,
@@ -431,6 +441,7 @@ namespace Terminal {
             color_grid.add (color_button_white);
             color_grid.add (color_button_light);
             color_grid.add (color_button_dark);
+            color_grid.add (color_button_custom);
 
             var natural_copy_paste_button = new Granite.SwitchModelButton (_("Natural Copy/Paste")) {
                 description = _("Shortcuts don’t require Shift; may interfere with CLI apps")
@@ -549,6 +560,9 @@ namespace Terminal {
                 case Themes.DARK:
                     color_button_dark.active = true;
                     break;
+                case Themes.CUSTOM:
+                    color_button_custom.active = true;
+                    break;
             }
 
             color_button_dark.button_release_event.connect (() => {
@@ -564,6 +578,13 @@ namespace Terminal {
             color_button_white.button_release_event.connect (() => {
                 Application.settings.set_string ("theme", Themes.HIGH_CONTRAST);
                 return Gdk.EVENT_PROPAGATE;
+            });
+
+            color_button_custom.button_release_event.connect (() => {
+                color_button_custom.active = true;
+                open_color_preferences ();
+                menu_popover.popdown ();
+                return Gdk.EVENT_STOP;
             });
 
             Application.settings.bind (
@@ -1479,6 +1500,19 @@ namespace Terminal {
                 fullscreen ();
                 is_fullscreen = true;
             }
+        }
+
+        private void open_color_preferences () {
+            if (color_preferences_dialog == null) {
+                color_preferences_dialog = new Dialogs.ColorPreferences (this);
+                color_preferences_dialog.show_all ();
+
+                color_preferences_dialog.destroy.connect (() => {
+                    color_preferences_dialog = null;
+                });
+            }
+
+            color_preferences_dialog.present ();
         }
 
         private TerminalWidget get_term_widget (Granite.Widgets.Tab tab) {

--- a/src/Themes.vala
+++ b/src/Themes.vala
@@ -21,6 +21,7 @@ public class Terminal.Themes {
     public const string DARK = "dark";
     public const string HIGH_CONTRAST = "high-contrast";
     public const string LIGHT = "solarized-light";
+    public const string CUSTOM = "custom";
 
     // format is color01:color02:...:color16:background:foreground:cursor
     static construct {

--- a/src/Themes.vala
+++ b/src/Themes.vala
@@ -49,10 +49,14 @@ public class Terminal.Themes {
             var new_color = Gdk.RGBA ();
             // If custom palette invalid use a fallback one
             if (!new_color.parse (string_palette[i])) {
-                critical ("Color %i '%s' is not valid - using fallback palette", i, string_palette[i]);
-                return get_rgba_palette (
+                critical ("Color %i '%s' is not valid - replacing with default", i, string_palette[i]);
+                settings_valid = false;
+
+                var fallback_palette = get_string_palette (
                     Application.settings.get_boolean ("prefer-dark-style") ? DARK : LIGHT
                 );
+                string_palette[i] = fallback_palette[i];
+                new_color.parse (fallback_palette[i]);
             }
 
             rgba_palette[i] = new_color;

--- a/src/Themes.vala
+++ b/src/Themes.vala
@@ -62,6 +62,11 @@ public class Terminal.Themes {
             rgba_palette[i] = new_color;
         }
 
+        if (!settings_valid) {
+            /* Remove invalid colors from setting */
+            Application.settings.set_string ("palette", string.joinv (":", string_palette));
+        }
+
         return rgba_palette;
     }
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -18,6 +18,14 @@
 */
 
 namespace Terminal {
+    const int PALETTE_SIZE = 16;
+    const string[] HEX_PALETTE = {
+        "#073642", "#dc322f", "#859900", "#b58900",
+        "#268bd2", "#ec0048", "#2aa198", "#94a3a5",
+        "#586e75", "#cb4b16", "#859900", "#b58900",
+        "#268bd2", "#d33682", "#2aa198", "#EEEEEE"
+    };
+
     public class TerminalWidget : Vte.Terminal {
         enum DropTargets {
             URILIST,
@@ -257,14 +265,6 @@ namespace Terminal {
 
             Gdk.RGBA foreground_color = Gdk.RGBA ();
             foreground_color.parse (Application.settings.get_string ("foreground"));
-
-            const int PALETTE_SIZE = 16;
-            const string[] HEX_PALETTE = {
-                "#073642", "#dc322f", "#859900", "#b58900",
-                "#268bd2", "#ec0048", "#2aa198", "#94a3a5",
-                "#586e75", "#cb4b16", "#859900", "#b58900",
-                "#268bd2", "#d33682", "#2aa198", "#EEEEEE"
-            };
 
             var hex_palette = new string[PALETTE_SIZE + 1];
             var palette_setting_string = Application.settings.get_string ("palette");


### PR DESCRIPTION
Pulled from #552 
Fixes #418 

Potentially address #39 
Potentially addresses #71
Potentially address #501 
Partially addresses #507 
Potentially address #632 

Additional work:
 * [x] Fix appearance of dialog under RTL
 * [x] Add a reset to default palette button
 * [x] Name variables according to linked nominal color
 * [x] Add labels for light colors
 * [x] Tweak layout and add some margins  
 * [x] Persist user custom theme after switching to a builtin theme
 * [ ] Import a theme