### PR TITLE
Add "Follow System Style" toggle

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -85,6 +85,11 @@
       <summary>Whether or not to use an audible bell event alert</summary>
       <description>Used when hitting the end of a line like in GTK entries, but also for tab-completion when there are either no or multiple possible completions.</description>
     </key>
+    <key name="follow-system-style" type="b">
+      <default>false</default>
+      <summary>Follow the Pantheon dark style preference</summary>
+      <description>Terminal will use the Dark style if the user prefers a dark style, or Solarized Light otherwise. Overrides control of prefer-dark-style, hiding the options in the UI.</description>
+    </key>
     <key name="natural-copy-paste" type="b">
       <default>true</default>
       <summary>Defined whether to use ctrl-c or ctrl-shift-c for copy</summary>

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -87,8 +87,8 @@
     </key>
     <key name="follow-system-style" type="b">
       <default>false</default>
-      <summary>Follow the Pantheon dark style preference</summary>
-      <description>Terminal will use the Dark style if the user prefers a dark style, or Solarized Light otherwise. Overrides control of prefer-dark-style, hiding the options in the UI.</description>
+      <summary>Follow the FreeDesktop.org dark style preference</summary>
+      <description>Use the Dark style if the system prefers a dark style, or Solarized Light otherwise. Overrides control of prefer-dark-style.</description>
     </key>
     <key name="natural-copy-paste" type="b">
       <default>true</default>
@@ -97,8 +97,8 @@
     </key>
     <key name="prefer-dark-style" type="b">
       <default>true</default>
-      <summary>Defined whether to use dark stylesheet from Gtk</summary>
-      <description>Switches between dark and light style</description>
+      <summary>Whether or not the custom theme should use a dark or light window style</summary>
+      <description>Switches between dark and light style when using the custom theme</description>
     </key>
 
     <key name="foreground" type="s">

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -8,7 +8,6 @@
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public
 * License along with this program; if not, write to the
@@ -633,6 +632,11 @@ namespace Terminal {
                 SettingsBindFlags.DEFAULT
             );
 
+            var granite_settings = Granite.Settings.get_default ();
+            granite_settings.notify["prefers-color-scheme"].connect (() => {
+                Application.settings.changed ("theme"); // Signal terminal widgets to update their color scheme
+            });
+            
             bind_property ("title", header, "title", GLib.BindingFlags.SYNC_CREATE);
 
             key_press_event.connect ((event) => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -636,7 +636,7 @@ namespace Terminal {
             granite_settings.notify["prefers-color-scheme"].connect (() => {
                 Application.settings.changed ("theme"); // Signal terminal widgets to update their color scheme
             });
-            
+
             bind_property ("title", header, "title", GLib.BindingFlags.SYNC_CREATE);
 
             key_press_event.connect ((event) => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -395,6 +395,26 @@ namespace Terminal {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
+            var follow_system_label = new Gtk.Label (_("Follow System Style")) {
+                halign = Gtk.Align.START,
+                hexpand = true,
+                vexpand = true
+            };
+
+            var follow_system_switch = new Gtk.Switch () {
+                valign = Gtk.Align.START
+            };
+
+            var follow_system_button_grid = new Gtk.Grid () {
+                column_spacing = 12
+            };
+            follow_system_button_grid.add (follow_system_label);
+            follow_system_button_grid.add (follow_system_switch);
+
+            var follow_system_button = new Gtk.ModelButton ();
+            follow_system_button.get_child ().destroy ();
+            follow_system_button.add (follow_system_button_grid);
+
             var color_button_white = new Gtk.RadioButton (null) {
                 halign = Gtk.Align.CENTER,
                 tooltip_text = _("High Contrast")
@@ -443,6 +463,15 @@ namespace Terminal {
             color_grid.add (color_button_dark);
             color_grid.add (color_button_custom);
 
+            var color_revealer = new Gtk.Revealer ();
+            color_revealer.add (color_grid);
+
+            var follow_system_grid = new Gtk.Grid () {
+                orientation = Gtk.Orientation.VERTICAL
+            };
+            follow_system_grid.add (follow_system_button);
+            follow_system_grid.add (color_revealer);
+
             var natural_copy_paste_button = new Granite.SwitchModelButton (_("Natural Copy/Paste")) {
                 description = _("Shortcuts don’t require Shift; may interfere with CLI apps")
             };
@@ -456,7 +485,7 @@ namespace Terminal {
             };
 
             menu_popover_grid.add (font_size_grid);
-            menu_popover_grid.add (color_grid);
+            menu_popover_grid.add (follow_system_grid);
             menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_popover_grid.add (natural_copy_paste_button);
 
@@ -586,6 +615,25 @@ namespace Terminal {
                 menu_popover.popdown ();
                 return Gdk.EVENT_STOP;
             });
+
+            follow_system_button.button_release_event.connect (() => {
+                follow_system_switch.activate ();
+                return Gdk.EVENT_STOP;
+            });
+
+            follow_system_switch.bind_property (
+                "active",
+                color_revealer,
+                "reveal-child",
+                GLib.BindingFlags.SYNC_CREATE | BindingFlags.INVERT_BOOLEAN
+            );
+
+            Application.settings.bind (
+                "follow-system-style",
+                follow_system_switch,
+                "active",
+                SettingsBindFlags.DEFAULT
+            );
 
             Application.settings.bind (
                 "natural-copy-paste",
@@ -1191,7 +1239,7 @@ namespace Terminal {
             });
             tab.ellipsize_mode = Pango.EllipsizeMode.MIDDLE;
 
-            /* Granite.Accel.from_action_name () does not allow control of which accel is used when 
+            /* Granite.Accel.from_action_name () does not allow control of which accel is used when
              * there are multiple so we have to use the other constructor to specify it. */
             var reload_menu_item = new Gtk.MenuItem () {
                 child = new Granite.AccelLabel (_("Reload"), ACTION_RELOAD_PREFERRED_ACCEL)

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -606,11 +606,6 @@ namespace Terminal {
                 SettingsBindFlags.DEFAULT
             );
 
-            var granite_settings = Granite.Settings.get_default ();
-            granite_settings.notify["prefers-color-scheme"].connect (() => {
-                Application.settings.changed ("theme"); // Signal terminal widgets to update their color scheme
-            });
-
             bind_property ("title", header, "title", GLib.BindingFlags.SYNC_CREATE);
 
             key_press_event.connect ((event) => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -456,7 +456,8 @@ namespace Terminal {
             color_revealer.add (color_grid);
 
             var follow_system_grid = new Gtk.Grid () {
-                orientation = Gtk.Orientation.VERTICAL
+                orientation = Gtk.Orientation.VERTICAL,
+                row_spacing = 6
             };
             follow_system_grid.add (follow_system_button);
             follow_system_grid.add (color_revealer);
@@ -474,6 +475,7 @@ namespace Terminal {
             };
 
             menu_popover_grid.add (font_size_grid);
+            menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_popover_grid.add (follow_system_grid);
             menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_popover_grid.add (natural_copy_paste_button);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -8,6 +8,7 @@
 * This program is distributed in the hope that it will be useful,
 * but WITHOUT ANY WARRANTY; without even the implied warranty of
 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
 *
 * You should have received a copy of the GNU Lesser General Public
 * License along with this program; if not, write to the
@@ -394,25 +395,7 @@ namespace Terminal {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
-            var follow_system_label = new Gtk.Label (_("Follow System Style")) {
-                halign = Gtk.Align.START,
-                hexpand = true,
-                vexpand = true
-            };
-
-            var follow_system_switch = new Gtk.Switch () {
-                valign = Gtk.Align.START
-            };
-
-            var follow_system_button_grid = new Gtk.Grid () {
-                column_spacing = 12
-            };
-            follow_system_button_grid.add (follow_system_label);
-            follow_system_button_grid.add (follow_system_switch);
-
-            var follow_system_button = new Gtk.ModelButton ();
-            follow_system_button.get_child ().destroy ();
-            follow_system_button.add (follow_system_button_grid);
+            var follow_system_switchmodelbutton = new Granite.SwitchModelButton (_("Follow System Style"));
 
             var color_button_white = new Gtk.RadioButton (null) {
                 halign = Gtk.Align.CENTER,
@@ -441,9 +424,8 @@ namespace Terminal {
 
             var color_grid = new Gtk.Grid () {
                 column_homogeneous = true,
-                margin_start = 12,
-                margin_end = 12,
-                margin_bottom = 6
+                margin_bottom = 6,
+                margin_top = 6
             };
 
             color_grid.add (color_button_white);
@@ -454,12 +436,9 @@ namespace Terminal {
             var color_revealer = new Gtk.Revealer ();
             color_revealer.add (color_grid);
 
-            var follow_system_grid = new Gtk.Grid () {
-                orientation = Gtk.Orientation.VERTICAL,
-                row_spacing = 6
-            };
-            follow_system_grid.add (follow_system_button);
-            follow_system_grid.add (color_revealer);
+            var follow_system_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
+            follow_system_box.add (follow_system_switchmodelbutton);
+            follow_system_box.add (color_revealer);
 
             var natural_copy_paste_button = new Granite.SwitchModelButton (_("Natural Copy/Paste")) {
                 description = _("Shortcuts don’t require Shift; may interfere with CLI apps")
@@ -475,7 +454,7 @@ namespace Terminal {
 
             menu_popover_grid.add (font_size_grid);
             menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-            menu_popover_grid.add (follow_system_grid);
+            menu_popover_grid.add (follow_system_box);
             menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_popover_grid.add (natural_copy_paste_button);
 
@@ -606,12 +585,7 @@ namespace Terminal {
                 return Gdk.EVENT_STOP;
             });
 
-            follow_system_button.button_release_event.connect (() => {
-                follow_system_switch.activate ();
-                return Gdk.EVENT_STOP;
-            });
-
-            follow_system_switch.bind_property (
+            follow_system_switchmodelbutton.bind_property (
                 "active",
                 color_revealer,
                 "reveal-child",
@@ -620,7 +594,7 @@ namespace Terminal {
 
             Application.settings.bind (
                 "follow-system-style",
-                follow_system_switch,
+                follow_system_switchmodelbutton,
                 "active",
                 SettingsBindFlags.DEFAULT
             );

--- a/src/Themes.vala
+++ b/src/Themes.vala
@@ -21,6 +21,7 @@ public class Terminal.Themes {
     public const string HIGH_CONTRAST = "high-contrast";
     public const string LIGHT = "solarized-light";
     public const string CUSTOM = "custom";
+    public const string SYSTEM = "system";
     public const int PALETTE_SIZE = 19;
 
     static construct {
@@ -72,7 +73,21 @@ public class Terminal.Themes {
 
     private static string[] get_string_palette (string theme) {
         var string_palette = new string[PALETTE_SIZE];
-        switch (theme) {
+        string theme_eff = DARK;
+        if (theme == SYSTEM) {
+            switch (Granite.Settings.get_default ().prefers_color_scheme) {
+                case Granite.Settings.ColorScheme.DARK:
+                    break;
+                case Granite.Settings.ColorScheme.LIGHT:
+                case Granite.Settings.ColorScheme.NO_PREFERENCE:
+                    theme_eff = LIGHT;
+                    break;
+            }
+        } else {
+            theme_eff = theme;
+        }
+
+        switch (theme_eff) {
             case (HIGH_CONTRAST):
                 string_palette = {
                     "#073642", "#dc322f", "#859900", "#b58900", "#268bd2", "#ec0048", "#2aa198", "#94a3a5",

--- a/src/Themes.vala
+++ b/src/Themes.vala
@@ -21,7 +21,6 @@ public class Terminal.Themes {
     public const string HIGH_CONTRAST = "high-contrast";
     public const string LIGHT = "solarized-light";
     public const string CUSTOM = "custom";
-    public const string SYSTEM = "system";
     public const int PALETTE_SIZE = 19;
 
     static construct {
@@ -73,21 +72,7 @@ public class Terminal.Themes {
 
     private static string[] get_string_palette (string theme) {
         var string_palette = new string[PALETTE_SIZE];
-        string theme_eff = DARK;
-        if (theme == SYSTEM) {
-            switch (Granite.Settings.get_default ().prefers_color_scheme) {
-                case Granite.Settings.ColorScheme.DARK:
-                    break;
-                case Granite.Settings.ColorScheme.LIGHT:
-                case Granite.Settings.ColorScheme.NO_PREFERENCE:
-                    theme_eff = LIGHT;
-                    break;
-            }
-        } else {
-            theme_eff = theme;
-        }
-
-        switch (theme_eff) {
+        switch (theme) {
             case (HIGH_CONTRAST):
                 string_palette = {
                     "#073642", "#dc322f", "#859900", "#b58900", "#268bd2", "#ec0048", "#2aa198", "#94a3a5",

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -257,7 +257,12 @@ namespace Terminal {
             if (Application.settings.get_boolean ("follow-system-style")) {
                 var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
                 gtk_settings.gtk_application_prefer_dark_theme = system_prefers_dark;
-                theme_palette = Themes.get_rgba_palette (Themes.SYSTEM);
+
+                if (system_prefers_dark) {
+                    theme_palette = Themes.get_rgba_palette (Themes.DARK);
+                } else {
+                    theme_palette = Themes.get_rgba_palette (Themes.LIGHT);
+                }
             } else {
                 gtk_settings.gtk_application_prefer_dark_theme = Application.settings.get_boolean ("prefer-dark-style");
                 theme_palette = Themes.get_rgba_palette (Application.settings.get_string ("theme"));

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -252,20 +252,16 @@ namespace Terminal {
 
         public void restore_settings () {
             /* Load configuration */
-            var follow_system_style = Application.settings.get_boolean ("follow-system-style");
             var gtk_settings = Gtk.Settings.get_default ();
-            var granite_settings = Granite.Settings.get_default ();
-            if (follow_system_style) {
-                gtk_settings.gtk_application_prefer_dark_theme =
-                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+            var theme_palette = new Gdk.RGBA[Themes.PALETTE_SIZE];
+            if (Application.settings.get_boolean ("follow-system-style")) {
+                var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+                gtk_settings.gtk_application_prefer_dark_theme = system_prefers_dark;
+                theme_palette = Themes.get_rgba_palette (Themes.SYSTEM);
             } else {
                 gtk_settings.gtk_application_prefer_dark_theme = Application.settings.get_boolean ("prefer-dark-style");
+                theme_palette = Themes.get_rgba_palette (Application.settings.get_string ("theme"));
             }
-
-            var theme_palette =
-                follow_system_style ?
-                Themes.get_rgba_palette (Themes.SYSTEM) :
-                Themes.get_rgba_palette (Application.settings.get_string ("theme"));
 
             var background = theme_palette[Themes.PALETTE_SIZE - 3];
             var foreground = theme_palette[Themes.PALETTE_SIZE - 2];

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -249,14 +249,24 @@ namespace Terminal {
 
         public void restore_settings () {
             /* Load configuration */
+            var follow_system_style = Application.settings.get_boolean ("follow-system-style");
             var gtk_settings = Gtk.Settings.get_default ();
-            gtk_settings.gtk_application_prefer_dark_theme = Application.settings.get_boolean ("prefer-dark-style");
+            var granite_settings = Granite.Settings.get_default ();
+            if (follow_system_style) {
+                gtk_settings.gtk_application_prefer_dark_theme =
+                granite_settings.prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+            } else {
+                gtk_settings.gtk_application_prefer_dark_theme = Application.settings.get_boolean ("prefer-dark-style");
+            }
 
-            var theme_palette = Terminal.Themes.get_rgba_palette (Application.settings.get_string ("theme"));
+            var theme_palette =
+                follow_system_style ?
+                Themes.get_rgba_palette (Themes.SYSTEM) :
+                Themes.get_rgba_palette (Application.settings.get_string ("theme"));
 
-            var background = theme_palette[Terminal.Themes.PALETTE_SIZE - 3];
-            var foreground = theme_palette[Terminal.Themes.PALETTE_SIZE - 2];
-            var cursor = theme_palette[Terminal.Themes.PALETTE_SIZE - 1];
+            var background = theme_palette[Themes.PALETTE_SIZE - 3];
+            var foreground = theme_palette[Themes.PALETTE_SIZE - 2];
+            var cursor = theme_palette[Themes.PALETTE_SIZE - 1];
             var palette = theme_palette[0:16];
 
             set_colors (foreground, background, palette);

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -136,6 +136,9 @@ namespace Terminal {
             restore_settings ();
             Application.settings.changed.connect (restore_settings);
 
+            var granite_settings = Granite.Settings.get_default ();
+            granite_settings.notify["prefers-color-scheme"].connect (restore_settings);
+
             window = parent_window;
             child_has_exited = false;
             killed = false;


### PR DESCRIPTION
Fixes #618

The UX is copied from #546 

The mechanism for getting the widgets to update their color scheme when the system default changes is somewhat non-obvious (the application settings are signaled to have changed even though they haven't) so as to make this work with the existing mechanism which requires an application settings change. 
