### PR TITLE
GSchema: change custom theme default values to Solarized Dark

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -97,7 +97,7 @@
     </key>
 
     <key name="foreground" type="s">
-      <default>"#a5a5a5"</default>
+      <default>"#93A1A1"</default>
       <summary>Color of the text.</summary>
       <description>
           The color of the text of the terminal.
@@ -109,7 +109,7 @@
       </description>
     </key>
     <key name="background" type="s">
-      <default>"rgba(46, 46, 46, 0.95)"</default>
+      <default>"#002B36"</default>
       <summary>Color of the background.</summary>
       <description>
           The color of the background of the terminal.


### PR DESCRIPTION
Make sure the custom theme isn't the same thing as the dark theme by default