### PR TITLE
build: Drop unused ubuntu-bionic-patched-vte option

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,0 @@
-option ('ubuntu-bionic-patched-vte', type : 'boolean', value : true)


### PR DESCRIPTION
Grepping this does not return other result for me, probably no longer useful after #675 (yeah we carry this option in nixpkgs since initial packaging so it is really nice to see we can drop this)