### PR TITLE
Add `SettingsPopover` Class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,10 @@ jobs:
         apt install -y desktop-file-utils gettext libgranite-dev libgtk-3-dev libhandy-1-dev libvte-2.91-dev libxml2-utils meson valac xvfb
     - name: Build
       run: |
-        meson build
-        ninja -C build
-        ninja -C build test
-        ninja -C build install
+        meson setup build
+        meson compile -C build
+        meson test -C build --print-errorlogs
+        meson install -C build
 
   lint:
     runs-on: ubuntu-latest

--- a/src/Dialogs/ColorPreferencesDialog.vala
+++ b/src/Dialogs/ColorPreferencesDialog.vala
@@ -237,6 +237,8 @@ public class Terminal.Dialogs.ColorPreferences : Granite.Dialog {
             contrast_top_label.label = Gtk.StateFlags.DIR_LTR in state_flags ? "┐" : "┌";
             contrast_bottom_label.label = Gtk.StateFlags.DIR_LTR in state_flags ? "┘" : "└";
         });
+
+        show.connect (get_child ().show_all);
     }
 
     private void update_palette_settings () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,13 +23,8 @@ namespace Terminal {
         private Gtk.Clipboard clipboard;
         private Gtk.Clipboard primary_selection;
         private Terminal.Widgets.SearchToolbar search_toolbar;
-        private Gtk.RadioButton color_button_custom;
-        private Gtk.RadioButton color_button_dark;
-        private Gtk.RadioButton color_button_light;
-        private Gtk.RadioButton color_button_white;
         private Gtk.Revealer search_revealer;
         private Gtk.ToggleButton search_button;
-        private Gtk.Button zoom_default_button;
         private Dialogs.ColorPreferences? color_preferences_dialog;
         private Granite.AccelLabel open_in_browser_menuitem_label;
 
@@ -78,6 +73,10 @@ namespace Terminal {
         public const string ACTION_SCROLL_TO_LAST_COMMAND = "action-scroll-to-last-command";
         public const string ACTION_OPEN_IN_BROWSER = "action-open-in-browser";
         public const string ACTION_RELOAD_PREFERRED_ACCEL = "<Shift><Control>R"; // Shown in context menu
+
+        public const string[] ACCELS_ZOOM_DEFAULT_FONT = { "<control>0", "<Control>KP_0" };
+        public const string[] ACCELS_ZOOM_IN_FONT = { "<Control>plus", "<Control>equal", "<Control>KP_Add" };
+        public const string[] ACCELS_ZOOM_OUT_FONT = { "<Control>minus", "<Control>KP_Subtract" };
 
         private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -144,13 +143,6 @@ namespace Terminal {
             action_accelerators[ACTION_PREVIOUS_TAB] = "<Control>Page_Up";
             action_accelerators[ACTION_MOVE_TAB_RIGHT] = "<Control><Alt>Right";
             action_accelerators[ACTION_MOVE_TAB_LEFT] = "<Control><Alt>Left";
-            action_accelerators[ACTION_ZOOM_DEFAULT_FONT] = "<Control>0";
-            action_accelerators[ACTION_ZOOM_DEFAULT_FONT] = "<Control>KP_0";
-            action_accelerators[ACTION_ZOOM_IN_FONT] = "<Control>plus";
-            action_accelerators[ACTION_ZOOM_IN_FONT] = "<Control>equal";
-            action_accelerators[ACTION_ZOOM_IN_FONT] = "<Control>KP_Add";
-            action_accelerators[ACTION_ZOOM_OUT_FONT] = "<Control>minus";
-            action_accelerators[ACTION_ZOOM_OUT_FONT] = "<Control>KP_Subtract";
             action_accelerators[ACTION_COPY] = "<Control><Shift>c";
             action_accelerators[ACTION_COPY_LAST_OUTPUT] = "<Alt>c";
             action_accelerators[ACTION_PASTE] = "<Control><Shift>v";
@@ -175,6 +167,10 @@ namespace Terminal {
 
                 app.set_accels_for_action (ACTION_PREFIX + action, accels_array);
             }
+
+            app.set_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_DEFAULT_FONT, ACCELS_ZOOM_DEFAULT_FONT);
+            app.set_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_IN_FONT, ACCELS_ZOOM_IN_FONT);
+            app.set_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_OUT_FONT, ACCELS_ZOOM_OUT_FONT);
 
             set_visual (Gdk.Screen.get_default ().get_rgba_visual ());
 
@@ -330,113 +326,10 @@ namespace Terminal {
                 tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>f"}, _("Find…"))
             };
 
-            var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU) {
-                action_name = ACTION_PREFIX + ACTION_ZOOM_OUT_FONT,
-                tooltip_markup = Granite.markup_accel_tooltip (
-                    application.get_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_OUT_FONT), _("Zoom out")
-                )
-            };
-
-            zoom_default_button = new Gtk.Button.with_label ("100%") {
-                action_name = ACTION_PREFIX + ACTION_ZOOM_DEFAULT_FONT,
-                tooltip_markup = Granite.markup_accel_tooltip (
-                    application.get_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_DEFAULT_FONT),
-                    _("Default zoom level")
-                )
-            };
-
-            var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", Gtk.IconSize.MENU) {
-                action_name = ACTION_PREFIX + ACTION_ZOOM_IN_FONT,
-                tooltip_markup = Granite.markup_accel_tooltip (
-                    application.get_accels_for_action (ACTION_PREFIX + ACTION_ZOOM_IN_FONT), _("Zoom in")
-                )
-            };
-
-            var font_size_grid = new Gtk.Grid () {
-                column_homogeneous = true,
-                hexpand = true,
-                margin_start = 12,
-                margin_end = 12,
-                margin_bottom = 6
-            };
-            font_size_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
-
-            font_size_grid.add (zoom_out_button);
-            font_size_grid.add (zoom_default_button);
-            font_size_grid.add (zoom_in_button);
-
-            var follow_system_switchmodelbutton = new Granite.SwitchModelButton (_("Follow System Style"));
-
-            color_button_white = new Gtk.RadioButton (null) {
-                halign = Gtk.Align.CENTER,
-                tooltip_text = _("High Contrast")
-            };
-            style_color_button (color_button_white, Themes.HIGH_CONTRAST);
-
-            color_button_light = new Gtk.RadioButton.from_widget (color_button_white) {
-                halign = Gtk.Align.CENTER,
-                tooltip_text = _("Solarized Light")
-            };
-            style_color_button (color_button_light, Themes.LIGHT);
-
-            color_button_dark = new Gtk.RadioButton.from_widget (color_button_white) {
-                halign = Gtk.Align.CENTER,
-                tooltip_text = _("Dark")
-            };
-            style_color_button (color_button_dark, Themes.DARK);
-
-            color_button_custom = new Gtk.RadioButton.from_widget (color_button_white) {
-                halign = Gtk.Align.CENTER,
-                tooltip_text = _("Custom")
-            };
-            color_button_custom.get_style_context ().add_class ("color-custom");
-            style_color_button (color_button_custom, Themes.CUSTOM);
-
-            var color_grid = new Gtk.Grid () {
-                column_homogeneous = true,
-                margin_bottom = 6,
-                margin_top = 6
-            };
-
-            color_grid.add (color_button_white);
-            color_grid.add (color_button_light);
-            color_grid.add (color_button_dark);
-            color_grid.add (color_button_custom);
-
-            var color_revealer = new Gtk.Revealer ();
-            color_revealer.add (color_grid);
-
-            var follow_system_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
-            follow_system_box.add (follow_system_switchmodelbutton);
-            follow_system_box.add (color_revealer);
-
-            var natural_copy_paste_button = new Granite.SwitchModelButton (_("Natural Copy/Paste")) {
-                description = _("Shortcuts don’t require Shift; may interfere with CLI apps")
-            };
-
-            var menu_popover_grid = new Gtk.Grid () {
-                column_spacing = 6,
-                margin_bottom = 6,
-                margin_top = 12,
-                orientation = Gtk.Orientation.VERTICAL,
-                row_spacing = 6
-            };
-
-            menu_popover_grid.add (font_size_grid);
-            menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-            menu_popover_grid.add (follow_system_box);
-            menu_popover_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
-            menu_popover_grid.add (natural_copy_paste_button);
-
-            menu_popover_grid.show_all ();
-
-            var menu_popover = new Gtk.Popover (null);
-            menu_popover.add (menu_popover_grid);
-
             var menu_button = new Gtk.MenuButton () {
                 can_focus = false,
                 image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
-                popover = menu_popover,
+                popover = new SettingsPopover (),
                 tooltip_text = _("Settings"),
                 valign = Gtk.Align.CENTER
             };
@@ -495,79 +388,19 @@ namespace Terminal {
             get_style_context ().add_class ("terminal-window");
             add (grid);
 
-            update_active_colorbutton ();
+            unowned var menu_popover = (SettingsPopover) menu_button.popover;
 
-            menu_popover.closed.connect (() => {
-                var binding = menu_popover.get_data<Binding> ("zoom-binding");
-                binding.unref ();
-                current_terminal.grab_focus ();
-            });
+            menu_popover.show_theme_editor.connect (() => {
+                if (color_preferences_dialog == null) {
+                    color_preferences_dialog = new Dialogs.ColorPreferences (this);
+                }
 
-            menu_button.clicked.connect (() => {
-                zoom_default_button.label = font_scale_to_zoom (current_terminal.font_scale);
-                var binding = current_terminal.bind_property (
-                    "font-scale",
-                    zoom_default_button,
-                    "label",
-                    BindingFlags.DEFAULT,
-
-                    (binding, from_val, ref to_val) => {
-                        to_val.set_string (font_scale_to_zoom (from_val.get_double ()));
-                        return true;
-                    }
-                );
-
-                menu_popover.set_data<Binding> ("zoom-binding", binding);
-            });
-
-            color_button_dark.button_release_event.connect (() => {
-                Application.settings.set_string ("theme", Themes.DARK);
-                return Gdk.EVENT_PROPAGATE;
-            });
-
-            color_button_light.button_release_event.connect (() => {
-                Application.settings.set_string ("theme", Themes.LIGHT);
-                return Gdk.EVENT_PROPAGATE;
-            });
-
-            color_button_white.button_release_event.connect (() => {
-                Application.settings.set_string ("theme", Themes.HIGH_CONTRAST);
-                return Gdk.EVENT_PROPAGATE;
-            });
-
-            color_button_custom.button_release_event.connect (() => {
-                color_button_custom.active = true;
-                open_color_preferences ();
-                menu_popover.popdown ();
-                return Gdk.EVENT_STOP;
-            });
-
-            follow_system_switchmodelbutton.bind_property (
-                "active",
-                color_revealer,
-                "reveal-child",
-                GLib.BindingFlags.SYNC_CREATE | BindingFlags.INVERT_BOOLEAN
-            );
-
-            Application.settings.bind (
-                "follow-system-style",
-                follow_system_switchmodelbutton,
-                "active",
-                SettingsBindFlags.DEFAULT
-            );
-
-            Application.settings.bind (
-                "natural-copy-paste",
-                natural_copy_paste_button,
-                "active",
-                SettingsBindFlags.DEFAULT
-            );
-
-            Application.settings.changed["theme"].connect (() => {
-                update_active_colorbutton ();
+                color_preferences_dialog.destroy.connect (() => color_preferences_dialog = null);
+                color_preferences_dialog.present ();
             });
 
             bind_property ("title", header, "title", GLib.BindingFlags.SYNC_CREATE);
+            bind_property ("current-terminal", menu_popover, "terminal");
 
             key_press_event.connect ((event) => {
                 if (event.is_modifier == 1) {
@@ -693,58 +526,6 @@ namespace Terminal {
 
                 return false;
             });
-
-            Application.settings.changed["background"].connect (() => {
-                style_color_button (color_button_custom, Themes.CUSTOM);
-            });
-
-            Application.settings.changed["foreground"].connect (() => {
-                style_color_button (color_button_custom, Themes.CUSTOM);
-            });
-        }
-
-        private void update_active_colorbutton () {
-            switch (Application.settings.get_string ("theme")) {
-                case Themes.HIGH_CONTRAST:
-                    color_button_white.active = true;
-                    break;
-                case Themes.LIGHT:
-                    color_button_light.active = true;
-                    break;
-                case Themes.DARK:
-                    color_button_dark.active = true;
-                    break;
-                case Themes.CUSTOM:
-                    color_button_custom.active = true;
-                    break;
-            }
-        }
-
-        private void style_color_button (Gtk.Widget color_button, string theme) {
-            var theme_palette = Terminal.Themes.get_rgba_palette (theme);
-
-            var background = theme_palette[Themes.PALETTE_SIZE - 3].to_string ();
-            var foreground = theme_palette[Themes.PALETTE_SIZE - 2].to_string ();
-
-            var style_css = """
-                .color-button radio {
-                    background-color: %s;
-                    color: %s;
-                    padding: 10px;
-                    -gtk-icon-shadow: none;
-                }
-            """.printf (background, foreground);
-
-            var css_provider = new Gtk.CssProvider ();
-            try {
-                css_provider.load_from_data (style_css);
-            } catch (Error e) {
-                critical ("Unable to style color button: %s", e.message);
-            }
-
-            unowned var style_context = color_button.get_style_context ();
-            style_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
-            style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         private bool handle_paste_event () {
@@ -1510,19 +1291,6 @@ namespace Terminal {
             }
         }
 
-        private void open_color_preferences () {
-            if (color_preferences_dialog == null) {
-                color_preferences_dialog = new Dialogs.ColorPreferences (this);
-                color_preferences_dialog.show_all ();
-
-                color_preferences_dialog.destroy.connect (() => {
-                    color_preferences_dialog = null;
-                });
-            }
-
-            color_preferences_dialog.present ();
-        }
-
         private TerminalWidget get_term_widget (Granite.Widgets.Tab tab) {
             return (TerminalWidget)((Gtk.Bin)tab.page).get_child ();
         }
@@ -1628,10 +1396,6 @@ namespace Terminal {
 
         public GLib.SimpleAction? get_simple_action (string action) {
             return actions.lookup_action (action) as GLib.SimpleAction;
-        }
-
-        private string font_scale_to_zoom (double font_scale) {
-            return ("%.0f%%").printf (font_scale * 100);
         }
     }
 }

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2023 elementary, Inc (https://elementary.io)
+ * SPDX-License-Identifier: LGPL-3.0-only
+ */
+
+public sealed class Terminal.SettingsPopover : Gtk.Popover {
+    public signal void show_theme_editor ();
+
+    public Vte.Terminal terminal {
+        owned get {
+            return terminal_binding.source as Vte.Terminal;
+        }
+
+        set {
+            terminal_binding.source = value;
+        }
+    }
+
+    private const string STYLE_CSS = """
+        .color-button radio {
+            background-color: %s;
+            color: %s;
+            padding: 10px;
+            -gtk-icon-shadow: none;
+        }
+    """;
+
+    private BindingGroup terminal_binding;
+    private Gtk.Box theme_buttons;
+
+    public SettingsPopover () {
+        Object ();
+    }
+
+    construct {
+        var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", MENU) {
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_OUT_FONT,
+            tooltip_markup = Granite.markup_accel_tooltip (
+                MainWindow.ACCELS_ZOOM_OUT_FONT,
+                _("Zoom out")
+            )
+        };
+
+        var zoom_default_button = new Gtk.Button () {
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT_FONT,
+            tooltip_markup = Granite.markup_accel_tooltip (
+                MainWindow.ACCELS_ZOOM_DEFAULT_FONT,
+                _("Default zoom level")
+            )
+        };
+
+        var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", MENU) {
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_IN_FONT,
+            tooltip_markup = Granite.markup_accel_tooltip (
+                MainWindow.ACCELS_ZOOM_IN_FONT,
+                _("Zoom in")
+            )
+        };
+
+        var font_size_box = new Gtk.Box (HORIZONTAL, 0) {
+            homogeneous = true,
+            hexpand = true,
+            margin_start = 12,
+            margin_end = 12,
+            margin_bottom = 6
+        };
+        font_size_box.add (zoom_out_button);
+        font_size_box.add (zoom_default_button);
+        font_size_box.add (zoom_in_button);
+
+        font_size_box.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+
+        theme_buttons = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
+            homogeneous = true,
+            margin_bottom = 6,
+            margin_top = 6
+        };
+
+        var theme_revealer = new Gtk.Revealer () {
+            child = theme_buttons
+        };
+
+        var follow_system_button = new Granite.SwitchModelButton (_("Follow System Style")) {
+            active = Application.settings.get_boolean ("follow-system-style"),
+        };
+
+        var theme_box = new Gtk.Box (VERTICAL, 0);
+        theme_box.add (follow_system_button);
+        theme_box.add (theme_revealer);
+
+        var hc_button = add_theme_button (Themes.HIGH_CONTRAST);
+        hc_button.tooltip_text = _("High Contrast");
+
+        var light_button = add_theme_button (Themes.LIGHT);
+        light_button.tooltip_text = _("Solarized Light");
+        light_button.group = hc_button;
+
+        var dark_button = add_theme_button (Themes.DARK);
+        dark_button.tooltip_text = _("Dark");
+        dark_button.group = hc_button;
+
+        Gtk.CssProvider custom_button_provider;
+
+        var custom_button = add_theme_button (Themes.CUSTOM, out custom_button_provider);
+        custom_button.tooltip_text = _("Custom");
+        custom_button.group = hc_button;
+        custom_button.get_style_context ().add_class ("color-custom");
+
+        update_active_colorbutton (dark_button, Application.settings.get_string ("theme"));
+
+        var natural_copy_paste_button = new Granite.SwitchModelButton (_("Natural Copy/Paste")) {
+            description = _("Shortcuts don’t require Shift; may interfere with CLI apps"),
+            active = Application.settings.get_boolean ("natural-copy-paste")
+        };
+
+        var box = new Gtk.Box (VERTICAL, 6) {
+            margin_bottom = 6,
+            margin_top = 12,
+        };
+
+        box.add (font_size_box);
+        box.add (new Gtk.Separator (HORIZONTAL));
+        box.add (theme_box);
+        box.add (new Gtk.Separator (HORIZONTAL));
+        box.add (natural_copy_paste_button);
+        child = box;
+
+        custom_button.clicked.connect (() => {
+            if (custom_button.active) {
+                show_theme_editor ();
+                popdown ();
+            }
+        });
+
+        terminal_binding = new BindingGroup ();
+        terminal_binding.bind_property ("font-scale", zoom_default_button, "label", SYNC_CREATE, font_scale_to_zoom);
+
+        follow_system_button.bind_property ("active", theme_revealer, "reveal-child", SYNC_CREATE | INVERT_BOOLEAN);
+
+        Application.settings.bind ("follow-system-style", follow_system_button, "active", DEFAULT);
+        Application.settings.bind ("natural-copy-paste", natural_copy_paste_button, "active", DEFAULT);
+
+        Application.settings.changed.connect ((s, n) => {
+            if (n == "background" || n == "foreground") {
+                update_theme_provider (custom_button_provider, Themes.CUSTOM);
+            } else if (n == "theme") {
+                update_active_colorbutton (dark_button, s.get_string (n));
+            }
+        });
+
+        show.connect (get_child ().show_all);
+    }
+
+    private Gtk.RadioButton add_theme_button (string theme, out Gtk.CssProvider css_provider = null) {
+        var button = new Gtk.RadioButton (null) {
+            action_target = new Variant.string (theme),
+            halign = Gtk.Align.CENTER
+        };
+
+        css_provider = new Gtk.CssProvider ();
+
+        unowned var style_context = button.get_style_context ();
+        style_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
+        style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+        update_theme_provider (css_provider, theme);
+
+        button.toggled.connect ((b) => {
+            if (((Gtk.RadioButton) b).active) {
+                Application.settings.set_value ("theme", b.action_target);
+            }
+        });
+
+        theme_buttons.add (button);
+        return button;
+    }
+
+    private static void update_active_colorbutton (Gtk.RadioButton default_button, string theme) {
+        SearchFunc<Gtk.RadioButton,string> find_colorbutton = (b, t) => strcmp (b.action_target.get_string (), t);
+        unowned var node = default_button.get_group ().search (theme, find_colorbutton);
+
+        if (node != null) {
+            node.data.active = true;
+        } else {
+            default_button.active = true;
+        }
+    }
+
+    private static void update_theme_provider (Gtk.CssProvider css_provider, string theme) {
+        var theme_palette = Themes.get_rgba_palette (theme);
+        var background = theme_palette[Themes.PALETTE_SIZE - 3].to_string ();
+        var foreground = theme_palette[Themes.PALETTE_SIZE - 2].to_string ();
+
+        try {
+            css_provider.load_from_data (STYLE_CSS.printf (background, foreground));
+        } catch (Error e) {
+            critical ("Unable to style color button: %s", e.message);
+        }
+    }
+
+    private static bool font_scale_to_zoom (Binding binding, Value font_scale, ref Value label) {
+        label.set_string ("%.0f%%".printf (font_scale.get_double () * 100));
+        return true;
+    }
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -17,6 +17,7 @@ terminal_sources = [
     'Dialogs/ForegroundProcessDialog.vala',
     'Dialogs/UnsafePasteDialog.vala',
     'Widgets/SearchToolbar.vala',
+    'Widgets/SettingsPopover.vala',
     'Widgets/TerminalWidget.vala',
     'Application.vala',
     'DBus.vala',


### PR DESCRIPTION
move the settings menu popover, and related functions to they own class.

the settings object is now, also used to keep the state between the widgets synchronized, and the actions provided by it make the new class mostly self-contained, only needing a single signal to indicate the window that the theme dialog should be shown.