### PR TITLE
Add shortcuts Ctrl + PageUp and Ctrl + PageDown to switch between tabs

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -158,8 +158,10 @@ namespace Terminal {
             action_accelerators[ACTION_NEW_WINDOW] = "<Control><Shift>n";
             action_accelerators[ACTION_NEXT_TAB] = "<Control><Shift>Right";
             action_accelerators[ACTION_NEXT_TAB] = "<Control>Tab";
+            action_accelerators[ACTION_NEXT_TAB] = "<Control>Page_Down";
             action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Left";
             action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Tab";
+            action_accelerators[ACTION_PREVIOUS_TAB] = "<Control>Page_Up";
             action_accelerators[ACTION_MOVE_TAB_RIGHT] = "<Control><Alt>Right";
             action_accelerators[ACTION_MOVE_TAB_LEFT] = "<Control><Alt>Left";
             action_accelerators[ACTION_ZOOM_DEFAULT_FONT] = "<Control>0";


### PR DESCRIPTION
_Control + PageUp_ and _Control + PageDown_ are common shortcuts to switch between tabs.
There are used by other apps such as Web, Chrome and Firefox, and other terminals like gnome-terminal.

This commit add these shortcuts to io.elementary.terminal.