### PR TITLE
Application: Properly Unexport the DBus Interface on Exit

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -8,6 +8,7 @@ public class Terminal.Application : Gtk.Application {
     public int minimum_height;
 
     private string commandline = "\0"; // used to temporary hold the argument to --commandline=
+    private uint dbus_id = 0;
 
     public static GLib.Settings saved_state;
     public static GLib.Settings settings;
@@ -102,11 +103,38 @@ public class Terminal.Application : Gtk.Application {
         return base.local_command_line (ref args, out exit_status);
     }
 
+    protected override int handle_local_options (VariantDict options) {
+        unowned string working_directory;
+        unowned string[] args;
+
+        if (options.lookup ("working-directory", "^&ay", out working_directory)) {
+            if (working_directory != "\0") {
+                Environment.set_current_dir (working_directory); // will be sent via platform-data
+            }
+
+            options.remove ("working-directory");
+        }
+
+        if (options.lookup (OPTION_REMAINING, "^a&ay", out args)) {
+            if (commandline != "\0") {
+                commandline += " %s".printf (string.joinv (" ", args));
+            } else {
+                commandline = string.joinv (" ", args);
+            }
+        }
+
+        if (commandline != "\0") {
+            options.insert ("commandline", "^&ay", commandline.escape ());
+        }
+
+        return -1;
+    }
+
     protected override bool dbus_register (DBusConnection connection, string object_path) throws Error {
         base.dbus_register (connection, object_path);
 
         var dbus = new DBus ();
-        connection.register_object (object_path, dbus);
+        dbus_id = connection.register_object (object_path, dbus);
 
         dbus.finished_process.connect ((id, process, exit_status) => {
             TerminalWidget terminal = null;
@@ -153,34 +181,7 @@ public class Terminal.Application : Gtk.Application {
         return true;
     }
 
-    public override int handle_local_options (VariantDict options) {
-        unowned string working_directory;
-        unowned string[] args;
-
-        if (options.lookup ("working-directory", "^&ay", out working_directory)) {
-            if (working_directory != "\0") {
-                Environment.set_current_dir (working_directory); // will be sent via platform-data
-            }
-
-            options.remove ("working-directory");
-        }
-
-        if (options.lookup (OPTION_REMAINING, "^a&ay", out args)) {
-            if (commandline != "\0") {
-                commandline += " %s".printf (string.joinv (" ", args));
-            } else {
-                commandline = string.joinv (" ", args);
-            }
-        }
-
-        if (commandline != "\0") {
-            options.insert ("commandline", "^&ay", commandline.escape ());
-        }
-
-        return -1;
-    }
-
-    public override int command_line (ApplicationCommandLine command_line) {
+    protected override int command_line (ApplicationCommandLine command_line) {
         unowned var options = command_line.get_options_dict ();
         var window = (MainWindow) active_window;
         bool new_window;
@@ -215,6 +216,14 @@ public class Terminal.Application : Gtk.Application {
 
         window.present ();
         return 0;
+    }
+
+    protected override void dbus_unregister (DBusConnection connection, string path) {
+        if (dbus_id != 0) {
+            connection.unregister_object (dbus_id);
+        }
+
+        base.dbus_unregister (connection, path);
     }
 
     public void new_window () {

--- a/src/tests/Application.vala
+++ b/src/tests/Application.vala
@@ -31,7 +31,9 @@ namespace Terminal.Test.Application {
             return 0;
         });
 
-        application.run (args);
+        if (application.run (args) != 0) {
+            GLib.Test.fail ();
+        }
     }
 
     private void option (string options, string platform_data, CommandLineCallback callback) {
@@ -58,7 +60,9 @@ namespace Terminal.Test.Application {
             return application.command_line (cmdline);
         });
 
-        application.run (null);
+        if (application.run (null) != 0) {
+            GLib.Test.fail ();
+        }
     }
 
     public static int main (string[] args) {


### PR DESCRIPTION
We where depending on the binary exiting to unexport the interface, however, the test suite launch a instance per test, and they where failing because of the interface being already registred, and ending in false positives.

the suite where ammended to check for the application exit status too and fail if not 0.