### PR TITLE
Remove ctrl + shift + left / right for tab switching

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -145,10 +145,8 @@ namespace Terminal {
             action_accelerators[ACTION_RELOAD_TAB] = ACTION_RELOAD_PREFERRED_ACCEL;
             action_accelerators[ACTION_RELOAD_TAB] = "<Shift>F5";
             action_accelerators[ACTION_NEW_WINDOW] = "<Control><Shift>n";
-            action_accelerators[ACTION_NEXT_TAB] = "<Control><Shift>Right";
             action_accelerators[ACTION_NEXT_TAB] = "<Control>Tab";
             action_accelerators[ACTION_NEXT_TAB] = "<Control>Page_Down";
-            action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Left";
             action_accelerators[ACTION_PREVIOUS_TAB] = "<Control><Shift>Tab";
             action_accelerators[ACTION_PREVIOUS_TAB] = "<Control>Page_Up";
             action_accelerators[ACTION_MOVE_TAB_RIGHT] = "<Control><Alt>Right";


### PR DESCRIPTION
This prevents this particular shortcut for interfering with the selection of text in some advanced TUI text editors like micro (fixes #676). 

We already have the following shortcuts for changing tabs:

ctrl + tab, ctrl + shift + tab;
ctrl + pgup, ctrl + pgdown;
ctrl + shift + pgup, ctrl + shift + pgdn;

These are all consistent with both Files and Web. Terminal should follow this standard as well.