### PR TITLE
Update manpage

### DIFF
--- a/debian/io.elementary.terminal.1
+++ b/debian/io.elementary.terminal.1
@@ -10,26 +10,26 @@ and follows the elementary OS Human Interface Guidelines.
 \fR[\fIOPTION...\fR]
 .SH OPTIONS
 .TP
+.BR \-e ", " \-\-execute =\fIPATH\fR
+Execute the specified binary in terminal
+.TP
 .BR \-h ", " \-\-help
 Show help message and exit
-.TP
-.BR \-v ", " \-\-version
-Print version info and exit
-.TP
-.BR \-t ", " \-\-new\-tab
-Open a terminal tab
 .TP
 .BR \-m ", " \-\-minimized
 Open a terminal in a minimized state
 .TP
-.BR \-e ", " \-\-execute =\fIPATH\fR
-Execute the specified binary in terminal
+.BR \-t ", " \-\-new\-tab
+Open a terminal tab
 .TP
-.BR \-x ", " \-\-commandline =\fICOMMAND\fR
-Run remainder of line as a command in terminal
+.BR \-v ", " \-\-version
+Print version info and exit
 .TP
 .BR \-w ", " \-\-working-directory =\fIPATH\fR
 Set the specified directory as shell working directory on startup
+.TP
+.BR \-x ", " \-\-commandline =\fICOMMAND\fR
+Run remainder of line as a command in terminal
 .SH AUTHOR
 Pantheon Terminal was written by Adrien Plazas <kekun.plazas@laposte.net>,
 Mario Guerriero <mario@elementaryos.org>,

--- a/debian/io.elementary.terminal.1
+++ b/debian/io.elementary.terminal.1
@@ -16,8 +16,17 @@ Show help message and exit
 .BR \-v ", " \-\-version
 Print version info and exit
 .TP
+.BR \-t ", " \-\-new\-tab
+Open a terminal tab
+.TP
+.BR \-m ", " \-\-minimized
+Open a terminal in a minimized state
+.TP
 .BR \-e ", " \-\-execute =\fIPATH\fR
-Execute the specified binary with given parameters in terminal.
+Execute the specified binary in terminal
+.TP
+.BR \-x ", " \-\-commandline =\fICOMMAND\fR
+Run remainder of line as a command in terminal
 .TP
 .BR \-w ", " \-\-working-directory =\fIPATH\fR
 Set the specified directory as shell working directory on startup

--- a/debian/io.elementary.terminal.1
+++ b/debian/io.elementary.terminal.1
@@ -11,7 +11,7 @@ and follows the elementary OS Human Interface Guidelines.
 .SH OPTIONS
 .TP
 .BR \-e ", " \-\-execute =\fIPATH\fR
-Execute the specified binary in terminal
+Execute the specified binary in a terminal
 .TP
 .BR \-h ", " \-\-help
 Show help message and exit
@@ -26,10 +26,10 @@ Open a terminal tab
 Print version info and exit
 .TP
 .BR \-w ", " \-\-working-directory =\fIPATH\fR
-Set the specified directory as shell working directory on startup
+Set the specified directory as the shell working directory on startup
 .TP
 .BR \-x ", " \-\-commandline =\fICOMMAND\fR
-Run remainder of line as a command in terminal
+Run the remainder of the line as a command in a terminal
 .SH AUTHOR
 Pantheon Terminal was written by Adrien Plazas <kekun.plazas@laposte.net>,
 Mario Guerriero <mario@elementaryos.org>,


### PR DESCRIPTION
Fixes #728 

* Add missing options
* Reorder options to alphabetical
* Use articles more consistently


Appearance of revised man page can be seen by running `groff -man -T ascii io.elementary.terminal.1` in the `debian` folder in a terminal