### PR TITLE
Expose audible-bell setting in Settings Menu

### DIFF
--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -113,7 +113,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
             active = Application.settings.get_boolean ("natural-copy-paste")
         };
 
-        var audible_bell_button = new Granite.SwitchModelButton (_("Audible Bell")) {
+        var audible_bell_button = new Granite.SwitchModelButton (_("Event Alerts")) {
             description = _("Send an event alert for invalid input or multiple possible completions (subject to system sound settings)"),
             active = Application.settings.get_boolean ("audible-bell")
         };

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -145,6 +145,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
 
         Application.settings.bind ("follow-system-style", follow_system_button, "active", DEFAULT);
         Application.settings.bind ("natural-copy-paste", natural_copy_paste_button, "active", DEFAULT);
+        Application.settings.bind ("audible-bell", audible_bell_button, "active", DEFAULT);
 
         Application.settings.changed.connect ((s, n) => {
             if (n == "background" || n == "foreground") {

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -114,7 +114,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
         };
 
         var audible_bell_button = new Granite.SwitchModelButton (_("Audible Bell")) {
-            description = _("Send an event alert for invalid input or multiple possible completions (subject to system sound settings)."),
+            description = _("Send an event alert for invalid input or multiple possible completions (subject to system sound settings)"),
             active = Application.settings.get_boolean ("audible-bell")
         };
 

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -114,7 +114,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
         };
 
         var audible_bell_button = new Granite.SwitchModelButton (_("Event Alerts")) {
-            description = _("Send an event alert for invalid input or multiple possible completions (subject to system sound settings)"),
+            description = _("Notify for invalid input or multiple possible completions (subject to System Settings → Sound)"),
             active = Application.settings.get_boolean ("audible-bell")
         };
 

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -113,6 +113,11 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
             active = Application.settings.get_boolean ("natural-copy-paste")
         };
 
+        var audible_bell_button = new Granite.SwitchModelButton (_("Audible Bell")) {
+            description = _("Send an event alert for invalid input or multiple possible completions (subject to system sound settings)."),
+            active = Application.settings.get_boolean ("audible-bell")
+        };
+
         var box = new Gtk.Box (VERTICAL, 6) {
             margin_bottom = 6,
             margin_top = 12,
@@ -123,6 +128,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
         box.add (theme_box);
         box.add (new Gtk.Separator (HORIZONTAL));
         box.add (natural_copy_paste_button);
+        box.add (audible_bell_button);
         child = box;
 
         custom_button.clicked.connect (() => {


### PR DESCRIPTION
Fixes #596 

A possible refinement of this would be to only show this option when the relevant system settings mean that an audible or visual notification will be made on an event alert.
