### PR TITLE
MainWindow: null terminate accel arrays

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -73,9 +73,9 @@ namespace Terminal {
         public const string ACTION_OPEN_IN_BROWSER = "action-open-in-browser";
         public const string ACTION_RELOAD_PREFERRED_ACCEL = "<Shift><Control>R"; // Shown in context menu
 
-        public const string[] ACCELS_ZOOM_DEFAULT_FONT = { "<control>0", "<Control>KP_0" };
-        public const string[] ACCELS_ZOOM_IN_FONT = { "<Control>plus", "<Control>equal", "<Control>KP_Add" };
-        public const string[] ACCELS_ZOOM_OUT_FONT = { "<Control>minus", "<Control>KP_Subtract" };
+        public const string[] ACCELS_ZOOM_DEFAULT_FONT = { "<control>0", "<Control>KP_0", null };
+        public const string[] ACCELS_ZOOM_IN_FONT = { "<Control>plus", "<Control>equal", "<Control>KP_Add", null };
+        public const string[] ACCELS_ZOOM_OUT_FONT = { "<Control>minus", "<Control>KP_Subtract", null };
 
         private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 


### PR DESCRIPTION
It looks like Terminal hasn't build in daily since #699 

Something with setting accels is causing tests to pass in CI here, but not during the launchpad build: https://launchpadlibrarian.net/695825095/buildlog_ubuntu-noble-amd64.io.elementary.terminal_6.1.2+r2374+pkg87~daily~ubuntu24.04.1_BUILDING.txt.gz

`stdout: 14: UNKNOWN: (/<<PKGBUILDDIR>>/obj-x86_64-linux-gnu/src/io.elementary.terminal.tests.application:8441): Gtk-WARNING **: 19:05:25.710: Unable to parse accelerator 'GVariant': ignored request to install 8 accelerators`

It looks like we null terminate the other arrays, so I'm guessing that's the problem?