### PR TITLE
Replace Granite.DynamicNotebook with Hdy TabView and TabBar

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -146,12 +146,7 @@ public class Terminal.Application : Gtk.Application {
                     break;
                 }
 
-                foreach (var term in window.terminals) {
-                    if (term.terminal_id == id) {
-                        terminal = term;
-                        break;
-                    }
-                }
+                terminal = window.get_terminal (id);
             }
 
             if (terminal == null) {
@@ -259,7 +254,7 @@ public class Terminal.Application : Gtk.Application {
             }
         } else if (options.lookup ("commandline", "^&ay", out command) && command != "\0") {
             window.add_tab_with_working_directory (working_directory, command, new_tab);
-        } else if (new_tab || window.terminals.is_empty ()) {
+        } else if (new_tab || window.notebook.n_pages == 0) {
             window.add_tab_with_working_directory (working_directory, null, new_tab);
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -356,7 +356,7 @@ namespace Terminal {
             notebook.tab_view.notify["selected-page"].connect (() => {
                 var term = get_term_widget (notebook.tab_view.selected_page);
                 if (term == null) {
-                    critical ("No terminal in selected page");
+                    // Happens on closing window - ignore
                     return;
                 }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -46,7 +46,6 @@ namespace Terminal {
             }
         }
 
-        private bool on_drag = false;
         private Gtk.EventControllerKey key_controller;
         private uint timer_window_state_change = 0;
         private uint focus_timeout = 0;
@@ -368,10 +367,6 @@ namespace Terminal {
                 });
             });
 
-            //TODO Implement DnD
-            // notebook.get_child ().drag_begin.connect (on_drag_begin);
-            // notebook.get_child ().drag_end.connect (on_drag_end);
-
             // var tab_bar_behavior = Application.settings.get_enum ("tab-bar-behavior");
             // notebook.tab_bar_behavior = (Granite.Widgets.DynamicNotebook.TabBarBehavior)tab_bar_behavior;
 
@@ -486,8 +481,8 @@ namespace Terminal {
         }
 
         private void on_tab_removed (Hdy.TabPage tab) {
-            if (!on_drag && notebook.n_pages == 0) {
-                // Close window when last tab removed
+            if (notebook.n_pages == 0) {
+                // Close window when last tab removed (Note: cannot drag last tab out of window)
                 save_opened_terminals (true, true);
                 destroy ();
             } else {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -73,6 +73,8 @@ namespace Terminal {
         public const string ACTION_CLOSE_OTHER_TABS = "action_close_other_tabs";
         public const string ACTION_FULLSCREEN = "action-fullscreen";
         public const string ACTION_NEW_TAB = "action-term_widgetnew-tab";
+        public const string ACTION_NEW_TAB_AT = "action-new-tab-at";
+        public const string ACTION_TAB_ACTIVE_SHELL = "action-tab_active_shell";
         public const string ACTION_RESTORE_CLOSED_TAB = "action-restore-closed-tab";
         public const string ACTION_DUPLICATE_TAB = "action-duplicate-tab";
         public const string ACTION_NEXT_TAB = "action-next-tab";
@@ -94,6 +96,8 @@ namespace Terminal {
             { ACTION_CLOSE_OTHER_TABS, action_close_other_tabs },
             { ACTION_FULLSCREEN, action_fullscreen },
             { ACTION_NEW_TAB, action_new_tab },
+            { ACTION_NEW_TAB_AT, action_new_tab_at, "s" },
+            { ACTION_TAB_ACTIVE_SHELL, action_tab_active_shell, "s" },
             { ACTION_RESTORE_CLOSED_TAB, action_restore_closed_tab, "s" },
             { ACTION_DUPLICATE_TAB, action_duplicate_tab },
             { ACTION_NEXT_TAB, action_next_tab },
@@ -927,6 +931,32 @@ namespace Terminal {
             } else {
                 new_tab (Environment.get_home_dir ());
             }
+        }
+
+        private void action_new_tab_at (GLib.SimpleAction action, GLib.Variant? param) {
+            var uri = param.get_string ();
+            new_tab (uri);
+        }
+
+        private void action_tab_active_shell (GLib.SimpleAction action, GLib.Variant? param) {
+            var path = param.get_string ();
+            var term = current_terminal;
+            // Ignore if foreground process running, for now.
+            if (term.has_foreground_process ()) {
+                return;
+            }
+
+            // Clear any partially entered command
+            //TODO Find a better way
+            var bs_string = string.nfill (1000, '\b');
+            term.feed_child (bs_string.data);
+
+            // Change to requested directory
+            var command = "cd '" + path + "'\n";
+            term.feed_child (command.data);
+
+            // Clear screen
+            term.feed_child ("clear\n".data);
         }
 
         private void action_duplicate_tab () requires (current_terminal != null) {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -143,4 +143,8 @@ namespace Terminal.Utils {
             allow_utf8
         ).replace (placeholder, "#");
     }
+
+    public SimpleAction action_from_group (string action_name, SimpleActionGroup action_group) {
+        return ((SimpleAction) action_group.lookup_action (action_name));
+    }
 }

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -1,0 +1,286 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/***
+  BEGIN LICENSE
+
+  Copyright (C) 2013 Mario Guerriero <mario@elementaryos.org>
+                2024 Colin Kiama <colinkiama@gmail.com>
+  This program is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License version 3, as published
+  by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranties of
+  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+  PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program.  If not, see <http://www.gnu.org/licenses/>
+
+  END LICENSE
+***/
+
+public class Terminal.TerminalView : Gtk.Box {
+    const int TAB_HISTORY_MAX_ITEMS = 20;
+
+    public enum TargetType {
+        URI_LIST
+    }
+
+    public signal void new_tab_requested ();
+    public signal void tab_duplicated (Hdy.TabPage page);
+    public signal void restorable_terminal_dropped (string id);
+    
+    public uint n_pages {
+        get {
+            return tab_view.n_pages;
+        }
+    }
+
+    public Hdy.TabPage selected_page {
+        get {
+            return tab_view.selected_page;
+        }
+        
+        set {
+            tab_view.selected_page = value;
+        }
+    }
+
+    public unowned MainWindow main_window { get; construct; }
+    public Hdy.TabView tab_view { get; construct; }
+    private Hdy.TabBar tab_bar;
+    private weak Hdy.TabPage? tab_menu_target = null;
+    private Gtk.CssProvider style_provider;
+    private Gtk.MenuButton tab_history_button;
+
+    public TerminalView (MainWindow window) {
+        Object (
+            main_window: window,
+            orientation: Gtk.Orientation.VERTICAL,
+            hexpand: true,
+            vexpand: true
+        );
+    }
+
+    construct {
+        var app_instance = (Gtk.Application) GLib.Application.get_default ();
+        tab_view = new Hdy.TabView () {
+            hexpand = true,
+            vexpand = true
+        };
+
+        tab_view.menu_model = create_menu_model ();
+        tab_view.setup_menu.connect (tab_view_setup_menu);
+
+        var new_tab_button = new Gtk.Button.from_icon_name ("list-add-symbolic") {
+            relief = Gtk.ReliefStyle.NONE,
+            tooltip_markup = Granite.markup_accel_tooltip (
+                app_instance.get_accels_for_action (MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_TAB),
+                _("New Tab")
+            ),
+            action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_TAB
+        };
+
+        tab_history_button = new Gtk.MenuButton () {
+            image = new Gtk.Image.from_icon_name ("document-open-recent-symbolic", Gtk.IconSize.MENU),
+            tooltip_text = _("Closed Tabs"),
+            use_popover = false,
+        };
+
+        tab_bar = new Hdy.TabBar () {
+            autohide = false,
+            expand_tabs = false,
+            inverted = true,
+            start_action_widget = new_tab_button,
+            end_action_widget = tab_history_button,
+            view = tab_view,
+        };
+
+        style_provider = new Gtk.CssProvider ();
+        Gtk.StyleContext.add_provider_for_screen (
+            Gdk.Screen.get_default (),
+            style_provider,
+            Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
+        );
+
+        // update_inline_tab_colors ();
+        
+        // Application.settings.changed["style-scheme"].connect (update_inline_tab_colors);
+        // Application.settings.changed["follow-system-style"].connect (update_inline_tab_colors);
+        // var granite_settings = Granite.Settings.get_default ();
+        // granite_settings.notify["prefers-color-scheme"].connect (update_inline_tab_colors);
+
+        // Handle Drag-and-drop of files onto add-tab button to create document
+        // Gtk.TargetEntry uris = {"text/uri-list", 0, TargetType.URI_LIST};
+        // Gtk.drag_dest_set (tab_bar, Gtk.DestDefaults.ALL, {uris}, Gdk.DragAction.COPY);
+        // tab_bar.drag_data_received.connect (drag_received);
+
+        add (tab_bar);
+        add (tab_view);
+    }
+
+    // private void update_inline_tab_colors () {
+        // var style_scheme = "";
+        // if (Application.settings.get_boolean ("follow-system-style")) {
+        //     var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+        //     if (system_prefers_dark) {
+        //         style_scheme = "elementary-dark";
+        //     } else {
+        //         style_scheme = "elementary-light";
+        //     }
+        // } else {
+        //     style_scheme = Application.settings.get_string ("style-scheme");
+        // }
+
+        // var sssm = Gtk.SourceStyleSchemeManager.get_default ();
+        // if (style_scheme in sssm.scheme_ids) {
+        //     var theme = sssm.get_scheme (style_scheme);
+        //     var text_color_data = theme.get_style ("text");
+
+        //     // Default gtksourceview background color is white
+        //     var color = "#FFFFFF";
+        //     if (text_color_data != null) {
+        //         // If the current style has a background color, use that
+        //         color = text_color_data.background;
+        //     }
+
+        //     var define = "@define-color tab_base_color %s;".printf (color);
+        //     try {
+        //         style_provider.load_from_data (define);
+        //     } catch (Error e) {
+        //         critical ("Unable to set inline tab styling, going back to classic notebook tabs");
+        //     }
+        // }
+    // }
+
+    public void make_restorable (TerminalWidget terminal) {
+warning ("TV make restorable %s, %s", terminal.current_working_directory, terminal.terminal_id);
+        if (tab_history_button.menu_model == null) {
+            tab_history_button.menu_model = new Menu ();
+        }
+
+        var path = terminal.current_working_directory;
+        var id = terminal.terminal_id;
+
+
+        var menu = (Menu) tab_history_button.menu_model;
+        int position_in_menu = -1;
+        var path_in_menu = false;
+        int i;
+        for (i = 0; i < menu.get_n_items (); i++) {
+            if (path == menu.get_item_attribute_value (
+                i, Menu.ATTRIBUTE_LABEL, VariantType.STRING).get_string ()
+            ) {
+                path_in_menu = true;
+                position_in_menu = i;
+                break;
+            }
+        }
+
+        if (path_in_menu) {
+warning ("path in menu true %s ", path);
+            var dropped_id = menu.get_item_attribute_value (
+                i, Menu.ATTRIBUTE_TARGET, VariantType.STRING
+            ).get_string ();
+            
+            restorable_terminal_dropped (dropped_id);
+            menu.remove (position_in_menu);
+        }
+
+        if (menu.get_n_items () >= TAB_HISTORY_MAX_ITEMS) {
+warning ("too many");
+            var dropped_id = menu.get_item_attribute_value (
+                TAB_HISTORY_MAX_ITEMS - 1, Menu.ATTRIBUTE_TARGET, VariantType.STRING
+            ).get_string ();
+            
+            restorable_terminal_dropped (dropped_id);
+            menu.remove (TAB_HISTORY_MAX_ITEMS - 1);
+        }
+
+        menu.prepend (
+            path,
+            "%s::%s".printf (MainWindow.ACTION_PREFIX + MainWindow.ACTION_RESTORE_CLOSED_TAB, id)
+        );
+    }
+
+    public void close_tabs_to_right () {
+        var target = tab_menu_target ?? tab_view.selected_page;
+
+        if (target == null) {
+            return;
+        }
+
+        tab_view.close_pages_after (target);
+        tab_view.selected_page = target;
+    }
+
+    public void close_other_tabs () {
+        var target = tab_menu_target ?? tab_view.selected_page;
+
+        if (target == null) {
+            return;
+        }
+
+        tab_view.close_other_pages (target);
+        tab_view.selected_page = target;
+    }
+
+    public void duplicate_tab () {
+
+    }
+
+    public void transfer_tab_to_new_window () {
+        var target = tab_menu_target ?? tab_view.selected_page;
+
+        if (target == null) {
+            return;
+        }
+
+        var new_window = new MainWindow (main_window.app, false);
+        tab_view.transfer_page (target, new_window.notebook.tab_view, 0);
+    }
+
+    // This is called when tab context menu is opened or closed
+    private void tab_view_setup_menu (Hdy.TabPage? page) {
+        tab_menu_target = page;
+
+        var close_other_tabs_action = Utils.action_from_group (MainWindow.ACTION_CLOSE_OTHER_TABS, main_window.actions);
+        var close_tabs_to_right_action = Utils.action_from_group (MainWindow.ACTION_CLOSE_TABS_TO_RIGHT, main_window.actions);
+
+        int page_position = page != null ? tab_view.get_page_position (page) : -1;
+
+        close_other_tabs_action.set_enabled (page != null && tab_view.n_pages > 1);
+        close_tabs_to_right_action.set_enabled (page != null && page_position != tab_view.n_pages - 1);
+    }
+
+    public void after_tab_restored (TerminalWidget term) {
+        var menu = (Menu) tab_history_button.menu_model;
+        for (var i = 0; i < menu.get_n_items (); i++) {
+            if (term.terminal_id == menu.get_item_attribute_value (i, Menu.ATTRIBUTE_TARGET, VariantType.STRING).get_string ()) {
+                menu.remove (i);
+                break;
+            }
+        }
+
+        if (menu.get_n_items () == 0) {
+            tab_history_button.menu_model = null;
+        }
+    }
+
+    private GLib.Menu create_menu_model () {
+        var menu = new GLib.Menu ();
+
+        var close_tab_section = new Menu ();
+        close_tab_section.append (_("Close Tabs to the Right"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_CLOSE_TABS_TO_RIGHT);
+        close_tab_section.append (_("Close Other Tabs"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_CLOSE_OTHER_TABS);
+        close_tab_section.append (_("Close Tab"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_CLOSE_TAB);
+
+        var open_tab_section = new Menu ();
+        open_tab_section.append (_("Open in New Window"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_MOVE_TAB_TO_NEW_WINDOW);
+        open_tab_section.append (_("Duplicate Tab"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_DUPLICATE_TAB);
+
+        menu.append_section (null, open_tab_section);
+        menu.append_section (null, close_tab_section);
+        return menu;
+    }
+}

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -104,8 +104,6 @@ public class Terminal.TerminalView : Gtk.Box {
 
         // update_inline_tab_colors ();
         
-        // Application.settings.changed["style-scheme"].connect (update_inline_tab_colors);
-        // Application.settings.changed["follow-system-style"].connect (update_inline_tab_colors);
         // var granite_settings = Granite.Settings.get_default ();
         // granite_settings.notify["prefers-color-scheme"].connect (update_inline_tab_colors);
 
@@ -118,45 +116,10 @@ public class Terminal.TerminalView : Gtk.Box {
         add (tab_view);
     }
 
-    // private void update_inline_tab_colors () {
-        // var style_scheme = "";
-        // if (Application.settings.get_boolean ("follow-system-style")) {
-        //     var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-        //     if (system_prefers_dark) {
-        //         style_scheme = "elementary-dark";
-        //     } else {
-        //         style_scheme = "elementary-light";
-        //     }
-        // } else {
-        //     style_scheme = Application.settings.get_string ("style-scheme");
-        // }
-
-        // var sssm = Gtk.SourceStyleSchemeManager.get_default ();
-        // if (style_scheme in sssm.scheme_ids) {
-        //     var theme = sssm.get_scheme (style_scheme);
-        //     var text_color_data = theme.get_style ("text");
-
-        //     // Default gtksourceview background color is white
-        //     var color = "#FFFFFF";
-        //     if (text_color_data != null) {
-        //         // If the current style has a background color, use that
-        //         color = text_color_data.background;
-        //     }
-
-        //     var define = "@define-color tab_base_color %s;".printf (color);
-        //     try {
-        //         style_provider.load_from_data (define);
-        //     } catch (Error e) {
-        //         critical ("Unable to set inline tab styling, going back to classic notebook tabs");
-        //     }
-        // }
-    // }
-
     public void make_restorable (string path) {
         if (tab_history_button.menu_model == null) {
             tab_history_button.menu_model = new Menu ();
         }
-
 
         var menu = (Menu) tab_history_button.menu_model;
         int position_in_menu = -1;

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -35,7 +35,6 @@ namespace Terminal {
 
         GLib.Pid child_pid;
         private MainWindow _window;
-
         public MainWindow window {
             get {
                 return _window;
@@ -50,17 +49,18 @@ namespace Terminal {
         }
 
         private Gtk.Menu menu;
-        public unowned Hdy.TabPage tab;
+        // There may be no associated tab while made restorable
+        public Hdy.TabPage tab { get; set; }
         public string? link_uri;
 
         // private string _tab_label;
         public string tab_label {
             get {
-                return tab.title;
+                return tab != null ? tab.title : "";
             }
 
             set {
-                if (value != null) {
+                            if (value != null && tab != null) {
                     tab.title = value;
                 }
             }
@@ -158,7 +158,7 @@ namespace Terminal {
         private bool modifier_pressed = false;
         private double scroll_delta = 0.0;
 
-        public signal void cwd_changed ();
+        public signal void cwd_changed (string cwd);
 
         public TerminalWidget (MainWindow parent_window) {
             pointer_autohide = true;
@@ -563,20 +563,17 @@ namespace Terminal {
         }
 
         void on_child_exited () {
-warning ("TW on child exited");
             child_has_exited = true;
             last_key_was_return = true;
         }
 
         public void kill_fg () {
-warning ("TW kill fg");
             int fg_pid;
             if (this.try_get_foreground_pid (out fg_pid))
                 Posix.kill (fg_pid, Posix.Signal.KILL);
         }
 
         public void term_ps () {
-warning ("TW term_ps");
             killed = true;
 
 #if HAS_LINUX
@@ -614,7 +611,6 @@ warning ("TW term_ps");
         }
 
         public void active_shell (string dir = GLib.Environment.get_current_dir ()) {
-warning ("active shell %s", dir);
             string shell = Application.settings.get_string ("shell");
             string?[] envv = null;
 
@@ -862,7 +858,7 @@ warning ("active shell %s", dir);
             var cwd = get_shell_location ();
             if (cwd != current_working_directory) {
                 current_working_directory = cwd;
-                cwd_changed ();
+                cwd_changed (cwd);
             }
         }
     }

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -50,19 +50,18 @@ namespace Terminal {
         }
 
         private Gtk.Menu menu;
-        public Granite.Widgets.Tab tab;
+        public unowned Hdy.TabPage tab;
         public string? link_uri;
 
-        private string _tab_label;
+        // private string _tab_label;
         public string tab_label {
             get {
-                return _tab_label;
+                return tab.title;
             }
 
             set {
                 if (value != null) {
-                    _tab_label = value;
-                    tab.label = tab_label;
+                    tab.title = value;
                 }
             }
         }
@@ -300,6 +299,10 @@ namespace Terminal {
                 }
             });
             action_group.add_action (zoom_action);
+        }
+
+        ~TerminalWidget () {
+            critical ("Terminal Widget destroyed");
         }
 
         private void pointer_focus () {
@@ -560,17 +563,20 @@ namespace Terminal {
         }
 
         void on_child_exited () {
+warning ("TW on child exited");
             child_has_exited = true;
             last_key_was_return = true;
         }
 
         public void kill_fg () {
+warning ("TW kill fg");
             int fg_pid;
             if (this.try_get_foreground_pid (out fg_pid))
                 Posix.kill (fg_pid, Posix.Signal.KILL);
         }
 
         public void term_ps () {
+warning ("TW term_ps");
             killed = true;
 
 #if HAS_LINUX
@@ -608,6 +614,7 @@ namespace Terminal {
         }
 
         public void active_shell (string dir = GLib.Environment.get_current_dir ()) {
+warning ("active shell %s", dir);
             string shell = Application.settings.get_string ("shell");
             string?[] envv = null;
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,7 @@ terminal_sources = [
     'Dialogs/UnsafePasteDialog.vala',
     'Widgets/SearchToolbar.vala',
     'Widgets/SettingsPopover.vala',
+    'Widgets/TerminalView.vala',
     'Widgets/TerminalWidget.vala',
     'Application.vala',
     'DBus.vala',

--- a/src/tests/Application.vala
+++ b/src/tests/Application.vala
@@ -145,14 +145,14 @@ namespace Terminal.Test.Application {
             option ("{'new-tab':<true>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.terminals.length ();
+                var n_tabs = (int) window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 2);
             });
 
             option ("{'new-tab':<false>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.terminals.length ();
+                var n_tabs = (int) window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 1);
             });
         });
@@ -176,7 +176,7 @@ namespace Terminal.Test.Application {
             option ("{'execute':<[b'%s']>}".printf (string.joinv ("',b'", execute)), "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.terminals.length ();
+                var n_tabs = (int) window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 5); // include the guaranted extra tab
             });
 
@@ -184,7 +184,7 @@ namespace Terminal.Test.Application {
             option ("{'execute':<[b'',b'',b'']>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.terminals.length ();
+                var n_tabs = (int) window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 1);
             });
         });


### PR DESCRIPTION
This adapts the DocumentView in Code which is already based on the Hdy widgets.

This mostly reproduces current behaviour except dropping files onto the tab bar now works.  

Note that the empty part of the tabbar is not accessible, it seems, so drops have to be either on the add button (which creates a new tab) or onto an existing tab (which changes the current directory.  Only local files and folders can be dropped.


Duplicating a tab creates the new tab next to the target tab (like in Browser)


