### PR TITLE
Fix transparent background

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -16,6 +16,7 @@
 * Boston, MA 02110-1301 USA
 */
 
+/* Make sure terminal background can use colors with alpha */
 .terminal-window.background {
     background-color: transparent;
 }

--- a/data/Application.css
+++ b/data/Application.css
@@ -36,3 +36,9 @@ vte-terminal {
 .color-custom radio:checked {
     -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
 }
+
+/* Workaround Hdy.Tabbar transparent area. Remove during GTK 4 port */
+tabbar .box {
+    margin: 0;
+    padding-top: 2px;
+}

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -377,7 +377,9 @@ namespace Terminal {
             var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
             box.add (header);
             box.add (notebook);
+
             add (box);
+            get_style_context ().add_class ("terminal-window");
 
             bind_property ("title", title_label, "label");
 


### PR DESCRIPTION
This style class is used to make sure custom colors can use alpha. Otherwise they'll just be overlaying on a solid color background