### PR TITLE
TerminalView: ReLoad→Reload

### DIFF
--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -215,7 +215,7 @@ public class Terminal.TerminalView : Gtk.Box {
         open_tab_section.append (_("Duplicate Tab"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_DUPLICATE_TAB);
 
         var reload_section = new Menu ();
-        reload_section.append (_("ReLoad"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_TAB_RELOAD);
+        reload_section.append (_("Reload"), MainWindow.ACTION_PREFIX + MainWindow.ACTION_TAB_RELOAD);
 
         menu.append_section (null, open_tab_section);
         menu.append_section (null, close_tab_section);


### PR DESCRIPTION
Tiny thing, but we're using `Reload` elsewhere:

https://l10n.elementary.io/search/?q=reload+language%3Aen&sort_by=-priority%2Cposition&checksum=

Originally reported from @edwood-grant on Weblate:

https://l10n.elementary.io/translate/terminal/terminal/en/?checksum=3b7b993be25291d0#comments