### PR TITLE
Fix empty context menu regression

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -201,6 +201,7 @@ namespace Terminal {
             context_menu.append (new Gtk.SeparatorMenuItem ());
             context_menu.append (search_menuitem);
             context_menu.insert_action_group ("win", actions);
+            context_menu.show_all ();
 
             setup_ui ();
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -57,7 +57,7 @@ namespace Terminal {
         public bool unsafe_ignored;
         public bool focus_restored_tabs { get; construct; default = true; }
         public bool recreate_tabs { get; construct; default = true; }
-        public Gtk.Menu menu { get; private set; }
+        public Gtk.Menu context_menu { get; private set; }
         public Terminal.Application app { get; construct; }
         public SimpleActionGroup actions { get; construct; }
 
@@ -191,16 +191,16 @@ namespace Terminal {
             };
             search_menuitem.add (new Granite.AccelLabel.from_action_name (_("Find…"), search_menuitem.action_name));
 
-            menu = new Gtk.Menu ();
-            menu.append (open_in_browser_menuitem);
-            menu.append (new Gtk.SeparatorMenuItem ());
-            menu.append (copy_menuitem);
-            menu.append (copy_last_output_menuitem);
-            menu.append (paste_menuitem);
-            menu.append (select_all_menuitem);
-            menu.append (new Gtk.SeparatorMenuItem ());
-            menu.append (search_menuitem);
-            menu.insert_action_group ("win", actions);
+            context_menu = new Gtk.Menu ();
+            context_menu.append (open_in_browser_menuitem);
+            context_menu.append (new Gtk.SeparatorMenuItem ());
+            context_menu.append (copy_menuitem);
+            context_menu.append (copy_last_output_menuitem);
+            context_menu.append (paste_menuitem);
+            context_menu.append (select_all_menuitem);
+            context_menu.append (new Gtk.SeparatorMenuItem ());
+            context_menu.append (search_menuitem);
+            context_menu.insert_action_group ("win", actions);
 
             setup_ui ();
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -42,9 +42,9 @@ namespace Terminal {
             }
         }
 
-        private Gtk.Menu menu {
+        private Gtk.Menu context_menu {
             get {
-                return main_window.menu;
+                return main_window.context_menu;
             }
         }
 
@@ -317,9 +317,8 @@ namespace Terminal {
                 Gdk.Rectangle rect = { (int) x, (int) y };
                 main_window.update_context_menu ();
                 setup_menu ();
-
-                menu.popup_at_rect (get_window (), rect, SOUTH_WEST, NORTH_WEST);
-                menu.select_first (false);
+                context_menu.popup_at_rect (get_window (), rect, SOUTH_WEST, NORTH_WEST);
+                context_menu.select_first (false);
 
                 gesture.set_state (CLAIMED);
             }
@@ -391,8 +390,8 @@ namespace Terminal {
                     setup_menu ();
 
                     // Popup context menu below cursor position
-                    menu.popup_at_rect (get_window (), rect, SOUTH_WEST, NORTH_WEST);
-                    menu.select_first (false);
+                    context_menu.popup_at_rect (get_window (), rect, SOUTH_WEST, NORTH_WEST);
+                    context_menu.select_first (false);
                     break;
 
                 case Gdk.Key.Alt_L:


### PR DESCRIPTION
Reinsert `show_all ()`


Also changes non-specific name `menu` to more specific `context_menu` to more easily distinguish from MenuButton popover menu.