### PR TITLE
Use Gtk.Menu

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -43,3 +43,12 @@ tabbar .box {
     margin: 0;
     padding-top: 2px;
 }
+
+/* Workaround for context menu styles. Remove during GTK4 port */
+menu {
+    font: initial;
+}
+
+menu separator {
+    font-size: 0;
+}

--- a/data/Application.css
+++ b/data/Application.css
@@ -48,7 +48,3 @@ tabbar .box {
 menu {
     font: initial;
 }
-
-menu separator {
-    font-size: 0;
-}

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -194,18 +194,19 @@ namespace Terminal {
             );
             select_all_menuitem.set_attribute_value ("accel", new Variant ("s", TerminalWidget.ACCELS_SELECT_ALL[0]));
 
-            context_menu_model = new Menu ();
-            // "Open in" item must be in position 0 (see update_menu_label ())
-            context_menu_model.append_item (open_in_browser_menuitem);
-
             var terminal_action_section = new Menu ();
             terminal_action_section.append_item (copy_menuitem);
             terminal_action_section.append_item (copy_last_output_menuitem);
             terminal_action_section.append_item (paste_menuitem);
             terminal_action_section.append_item (select_all_menuitem);
-            context_menu_model.append_section ("", terminal_action_section);
+
             var search_section = new Menu ();
             search_section.append_item (search_menuitem);
+
+            context_menu_model = new Menu ();
+            // "Open in" item must be in position 0 (see update_menu_label ())
+            context_menu_model.append_item (open_in_browser_menuitem);
+            context_menu_model.append_section ("", terminal_action_section);
             context_menu_model.append_section ("", search_section);
 
             setup_ui ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -206,8 +206,8 @@ namespace Terminal {
             context_menu_model = new Menu ();
             // "Open in" item must be in position 0 (see update_menu_label ())
             context_menu_model.append_item (open_in_browser_menuitem);
-            context_menu_model.append_section ("", terminal_action_section);
-            context_menu_model.append_section ("", search_section);
+            context_menu_model.append_section (null, terminal_action_section);
+            context_menu_model.append_section (null, search_section);
 
             setup_ui ();
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -454,14 +454,10 @@ namespace Terminal {
             setup_menu ();
 
             // Popup context menu below cursor position
-            var context_popover = new Gtk.PopoverMenu () {
-                relative_to = this,
-                pointing_to = rect
+            var context_menu = new Gtk.Menu.from_model (main_window.context_menu_model) {
+                attach_widget = this
             };
-
-            context_popover.bind_model (main_window.context_menu_model, null);
-            context_popover.show_all ();
-            context_popover.popup ();
+            context_menu.popup_at_rect (get_window (), rect, SOUTH_WEST, NORTH_WEST);
         }
 
         protected override void copy_clipboard () {


### PR DESCRIPTION
Needs some CSS here to fix stylesheet bugs, but this will show accelerators. Gotta make the section labels null or we get a weird bug with separator height being forced to match an empty label