### PR TITLE
Fix "Open in Terminal" from Files when Terminal instance already running

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -63,7 +63,8 @@ namespace Terminal.Utils {
             parts_sep[index] = construct_parent_path (shell_location);
         }
 
-        var result = escape_uri (scheme + string.joinv (Path.DIR_SEPARATOR_S, parts_sep).replace ("//", "/"));
+        // Terminal does not need an escaped uri
+        var result = scheme + string.joinv (Path.DIR_SEPARATOR_S, parts_sep).replace ("//", "/");
         return result;
     }
 


### PR DESCRIPTION
Fixes #775

The exact reason is uncertain but it appears that passing the working directory via the platform-data fails in some cases.  The solution suggested here does not remove the "working-directory" commandline option after setting the CWD and uses that to determine where to open the tab when it is available, falling back to the CWD when it is not.

The sanitization of the uri no longer escapes the uri as this is not needed (and can cause problems)