### PR TITLE
Gtk4Prep: Use CheckButtons for theme buttons

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -30,11 +30,11 @@ vte-terminal {
     padding: 0 9px;
 }
 
-.color-custom radio {
+.color-custom check {
     -gtk-icon-source: -gtk-icontheme("list-add-symbolic");
 }
 
-.color-custom radio:checked {
+.color-custom check:checked {
     -gtk-icon-source: -gtk-icontheme("check-active-symbolic");
 }
 


### PR DESCRIPTION
RadioButton does not exist in Gtk4
CheckButton group is not readable in Gtk4


Some extra code is required in Gtk3 to make the CheckButtons act as a group, which can be lost in Gtk4.