### PR TITLE
Gtk4Prep - Handle restoring and syncing window state in Application

### DIFF
--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -17,10 +17,15 @@
   </enum>
 
   <schema path="/io/elementary/terminal/saved-state/" id="io.elementary.terminal.saved-state">
-    <key name="window-size" type="(ii)">
-      <default>(-1, -1)</default>
-      <summary>Most recent window size</summary>
-      <description>Most recent window size (width, height)</description>
+    <key name="window-height" type="i">
+      <default>700</default>
+      <summary>Most recent window height</summary>
+      <description>Most recent window height</description>
+    </key>
+    <key name="window-width" type="i">
+      <default>1024</default>
+      <summary>Most recent window width</summary>
+      <description>Most recent window width</description>
     </key>
     <key name="window-state" enum="pantheon-terminal-window-states">
       <default>"Normal"</default>

--- a/data/io.elementary.terminal.gschema.xml
+++ b/data/io.elementary.terminal.gschema.xml
@@ -27,10 +27,10 @@
       <summary>Most recent window width</summary>
       <description>Most recent window width</description>
     </key>
-    <key name="window-state" enum="pantheon-terminal-window-states">
-      <default>"Normal"</default>
-      <summary>The saved state of the window.</summary>
-      <description>The saved state of the window.</description>
+    <key name="is-maximized" type="b">
+      <default>false</default>
+      <summary>Whether window is maximized</summary>
+      <description>Whether the main application window is maximized or not</description>
     </key>
     <key name="tabs" type="as">
       <default>[]</default>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -288,12 +288,35 @@ public class Terminal.Application : Gtk.Application {
             window.add_tab_with_working_directory (working_directory, null, new_tab);
         }
 
+        //TODO In Gtk4 we can just bind the settings to first window properties
+        // instead of this function
+        restore_saved_state (window, is_first_window);
+
         if (options.lookup ("minimized", "b", out minimized) && minimized) {
             window.iconify ();
         } else {
             window.present ();
         }
         return 0;
+    }
+
+    private void restore_saved_state (Gtk.Window window, bool is_first_window) {
+        if (Application.saved_state.get_boolean ("is-maximized")) {
+            window.maximize ();
+        } else {
+            window.resize (
+                Application.saved_state.get_int ("window-width"),
+                Application.saved_state.get_int ("window-height")
+            );
+        }
+
+        if (is_first_window) {
+            window.size_allocate.connect ((alloc) => {
+                Application.saved_state.set_int ("window-width", alloc.width);
+                Application.saved_state.set_int ("window-height", alloc.height);
+                Application.saved_state.set_boolean ("is-maximized", window.is_maximized);
+            });
+        }
     }
 
     protected override void dbus_unregister (DBusConnection connection, string path) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -301,19 +301,22 @@ public class Terminal.Application : Gtk.Application {
     }
 
     private void restore_saved_state (Gtk.Window window, bool is_first_window) {
+        window.resize (
+            Application.saved_state.get_int ("window-width"),
+            Application.saved_state.get_int ("window-height")
+        );
+
         if (Application.saved_state.get_boolean ("is-maximized")) {
             window.maximize ();
-        } else {
-            window.resize (
-                Application.saved_state.get_int ("window-width"),
-                Application.saved_state.get_int ("window-height")
-            );
         }
 
         if (is_first_window) {
             window.size_allocate.connect ((alloc) => {
-                Application.saved_state.set_int ("window-width", alloc.width);
-                Application.saved_state.set_int ("window-height", alloc.height);
+                if (!window.is_maximized) {
+                    Application.saved_state.set_int ("window-width", alloc.width);
+                    Application.saved_state.set_int ("window-height", alloc.height);
+                }
+
                 Application.saved_state.set_boolean ("is-maximized", window.is_maximized);
             });
         }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -231,7 +231,6 @@ namespace Terminal {
 
             set_size_request (app.minimum_width, app.minimum_height);
 
-            restore_saved_state ();
             show_all ();
 
             if (recreate_tabs) {
@@ -467,27 +466,6 @@ namespace Terminal {
             }
 
             return false;
-        }
-
-        private void restore_saved_state () {
-            if (Application.saved_state.get_boolean ("is-maximized")) {
-                maximize ();
-            } else {
-                //TODO In Gtk4 we can just bind the settings to the default width and default height
-                // for the first window
-                resize (
-                    Application.saved_state.get_int ("window-width"),
-                    Application.saved_state.get_int ("window-height")
-                );
-            }
-
-            size_allocate.connect ((alloc) => {
-                Application.saved_state.set_int ("window-width", alloc.width);
-                Application.saved_state.set_int ("window-height", alloc.height);
-                Application.saved_state.set_boolean ("is-maximized", is_maximized);
-            });
-
-
         }
 
         private void on_tab_added (Hdy.TabPage tab, int pos) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -48,7 +48,6 @@ namespace Terminal {
         }
 
         private Gtk.EventControllerKey key_controller;
-        private uint timer_window_state_change = 0;
         private uint focus_timeout = 0;
 
         private const int NORMAL = 0;
@@ -471,23 +470,24 @@ namespace Terminal {
         }
 
         private void restore_saved_state () {
-            //TODO In Gtk4 we can just bind the settings to the default width and default height
-            resize (
-                Application.saved_state.get_int ("window-width"),
-                Application.saved_state.get_int ("window-height")
-            );
+            if (Application.saved_state.get_boolean ("is-maximized")) {
+                maximize ();
+            } else {
+                //TODO In Gtk4 we can just bind the settings to the default width and default height
+                // for the first window
+                resize (
+                    Application.saved_state.get_int ("window-width"),
+                    Application.saved_state.get_int ("window-height")
+                );
+            }
 
             size_allocate.connect ((alloc) => {
-               Application.saved_state.set_int ("window-width", alloc.width);
-               Application.saved_state.set_int ("window-height", alloc.height);
+                Application.saved_state.set_int ("window-width", alloc.width);
+                Application.saved_state.set_int ("window-height", alloc.height);
+                Application.saved_state.set_boolean ("is-maximized", is_maximized);
             });
 
-            var window_state = Terminal.Application.saved_state.get_enum ("window-state");
-            if (window_state == MainWindow.MAXIMIZED) {
-                maximize ();
-            } else if (window_state == MainWindow.FULLSCREEN) {
-                is_fullscreen = true;
-            }
+
         }
 
         private void on_tab_added (Hdy.TabPage tab, int pos) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -471,18 +471,16 @@ namespace Terminal {
         }
 
         private void restore_saved_state () {
-            var rect = Gdk.Rectangle ();
-            Terminal.Application.saved_state.get ("window-size", "(ii)", out rect.width, out rect.height);
+            //TODO In Gtk4 we can just bind the settings to the default width and default height
+            resize (
+                Application.saved_state.get_int ("window-width"),
+                Application.saved_state.get_int ("window-height")
+            );
 
-            default_width = rect.width;
-            default_height = rect.height;
-
-            if (default_width == -1 || default_height == -1) {
-                var geometry = get_display ().get_primary_monitor ().get_geometry ();
-
-                default_width = geometry.width * 2 / 3;
-                default_height = geometry.height * 3 / 4;
-            }
+            size_allocate.connect ((alloc) => {
+               Application.saved_state.set_int ("window-width", alloc.width);
+               Application.saved_state.set_int ("window-height", alloc.height);
+            });
 
             var window_state = Terminal.Application.saved_state.get_enum ("window-state");
             if (window_state == MainWindow.MAXIMIZED) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -604,37 +604,6 @@ namespace Terminal {
             return appinfo;
         }
 
-        protected override bool configure_event (Gdk.EventConfigure event) {
-            // triggered when the size, position or stacking of the window has changed
-            // it is delayed 400ms to prevent spamming gsettings
-            if (timer_window_state_change > 0) {
-                GLib.Source.remove (timer_window_state_change);
-            }
-
-            timer_window_state_change = GLib.Timeout.add (400, () => {
-                timer_window_state_change = 0;
-                if (get_window () == null)
-                    return false;
-
-                /* Check for fullscreen first: https://github.com/elementary/terminal/issues/377 */
-                if ((get_window ().get_state () & Gdk.WindowState.FULLSCREEN) != 0) {
-                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.FULLSCREEN);
-                } else if (is_maximized) {
-                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.MAXIMIZED);
-                } else {
-                    Terminal.Application.saved_state.set_enum ("window-state", MainWindow.NORMAL);
-
-                    var rect = Gdk.Rectangle ();
-                    get_size (out rect.width, out rect.height);
-                    Terminal.Application.saved_state.set ("window-size", "(ii)", rect.width, rect.height);
-                }
-
-                return false;
-            });
-
-            return base.configure_event (event);
-        }
-
         private void open_tabs () {
             string[] tabs = {};
             double[] zooms = {};


### PR DESCRIPTION
 - Gtk4 Does not have configure-event
 - Follow pattern of Icon Browser (Gtk4) with regards to settings 
 - Restore saved state function can just be deleted on porting
 - Replaced by settings binding to window properties.