### PR TITLE
Gtk4 prep - Move zoom actions to MainWindow

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -250,9 +250,9 @@ public class Terminal.Application : Gtk.Application {
         set_accels_for_action (TerminalWidget.ACTION_RELOAD, TerminalWidget.ACCELS_RELOAD);
         set_accels_for_action (TerminalWidget.ACTION_SCROLL_TO_COMMAND, TerminalWidget.ACCELS_SCROLL_TO_COMMAND);
         set_accels_for_action (TerminalWidget.ACTION_SELECT_ALL, TerminalWidget.ACCELS_SELECT_ALL);
-        set_accels_for_action (TerminalWidget.ACTION_ZOOM_DEFAULT, TerminalWidget.ACCELS_ZOOM_DEFAULT);
-        set_accels_for_action (TerminalWidget.ACTION_ZOOM_IN, TerminalWidget.ACCELS_ZOOM_IN);
-        set_accels_for_action (TerminalWidget.ACTION_ZOOM_OUT, TerminalWidget.ACCELS_ZOOM_OUT);
+        set_accels_for_action (MainWindow.ACTION_ZOOM_DEFAULT, TerminalWidget.ACCELS_ZOOM_DEFAULT);
+        set_accels_for_action (MainWindow.ACTION_ZOOM_IN, TerminalWidget.ACCELS_ZOOM_IN);
+        set_accels_for_action (MainWindow.ACTION_ZOOM_OUT, TerminalWidget.ACCELS_ZOOM_OUT);
     }
 
     protected override int command_line (ApplicationCommandLine command_line) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -86,6 +86,10 @@ namespace Terminal {
         public const string ACTION_OPEN_IN_BROWSER = "action-open-in-browser";
         public const string ACTION_OPEN_IN_BROWSER_ACCEL = "<Control><Shift>e";
 
+        public const string ACTION_ZOOM = "action-zoom";
+        public const string ACTION_ZOOM_IN = "action-zoom::in";
+        public const string ACTION_ZOOM_OUT = "action-zoom::out";
+        public const string ACTION_ZOOM_DEFAULT = "action-zoom::default";
 
         private static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -108,7 +112,8 @@ namespace Terminal {
             { ACTION_SEARCH, action_search, null, "false" },
             { ACTION_SEARCH_NEXT, action_search_next },
             { ACTION_SEARCH_PREVIOUS, action_search_previous },
-            { ACTION_OPEN_IN_BROWSER, action_open_in_browser }
+            { ACTION_OPEN_IN_BROWSER, action_open_in_browser },
+            { ACTION_ZOOM, action_terminal_zoom, "s" }
         };
 
         public MainWindow (Terminal.Application app, bool recreate_tabs = true) {
@@ -855,6 +860,22 @@ namespace Terminal {
                     }
                 }
             });
+        }
+
+        private void action_terminal_zoom (SimpleAction action, Variant? param) {
+            switch (param.get_string ()) {
+                case "in":
+                    current_terminal.increase_font_size ();
+                    break;
+                case "default":
+                    current_terminal.default_font_size ();
+                    break;
+                case "out":
+                    current_terminal.decrease_font_size ();
+                    break;
+                default:
+                    assert_not_reached ();
+            }
         }
 
         private void get_current_selection_link_or_pwd (

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -42,7 +42,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom out")
             )
         };
-        zoom_out_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_OUT);
+        zoom_out_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_OUT);
 
         var zoom_default_button = new Gtk.Button () {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -50,7 +50,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Default zoom level")
             )
         };
-        zoom_default_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_DEFAULT);
+        zoom_out_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT);
 
         var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic") {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -58,7 +58,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom in")
             )
         };
-        zoom_in_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_IN);
+        zoom_out_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_IN);
 
         var font_size_box = new Gtk.Box (HORIZONTAL, 0) {
             homogeneous = true,

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -48,7 +48,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Default zoom level")
             )
         };
-        zoom_out_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT);
+        zoom_default_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT);
 
         var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic") {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -56,7 +56,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom in")
             )
         };
-        zoom_out_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_IN);
+        zoom_in_button.set_detailed_action_name (MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_IN);
 
         var font_size_box = new Gtk.Box (HORIZONTAL, 0) {
             homogeneous = true,

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -64,9 +64,6 @@ namespace Terminal {
         public const string ACTION_RELOAD = "term.reload";
         public const string ACTION_SCROLL_TO_COMMAND = "term.scroll-to-command";
         public const string ACTION_SELECT_ALL = "term.select-all";
-        public const string ACTION_ZOOM_DEFAULT = "term.zoom::default";
-        public const string ACTION_ZOOM_IN = "term.zoom::in";
-        public const string ACTION_ZOOM_OUT = "term.zoom::out";
 
         public const string[] ACCELS_COPY = { "<Control><Shift>C", null };
         public const string[] ACCELS_COPY_OUTPUT = { "<Alt>C", null };
@@ -275,22 +272,6 @@ namespace Terminal {
             var select_all_action = new GLib.SimpleAction ("select-all", null);
             select_all_action.activate.connect (select_all);
             action_group.add_action (select_all_action);
-
-            var zoom_action = new GLib.SimpleAction ("zoom", VariantType.STRING);
-            zoom_action.activate.connect ((p) => {
-                switch ((string) p) {
-                    case "in":
-                        increase_font_size ();
-                        break;
-                    case "out":
-                        decrease_font_size ();
-                        break;
-                    case "default":
-                        font_scale = 1.0;
-                        break;
-                }
-            });
-            action_group.add_action (zoom_action);
         }
 
         private void pointer_focus () {
@@ -705,12 +686,16 @@ namespace Terminal {
             }
         }
 
-        protected override void increase_font_size () {
+        public override void increase_font_size () {
             font_scale += 0.1;
         }
 
-        protected override void decrease_font_size () {
+        public override void decrease_font_size () {
             font_scale -= 0.1;
+        }
+
+        public void default_font_size () {
+            font_scale = 1.0;
         }
 
         public bool is_init_complete () {


### PR DESCRIPTION
Having the zoom actions in TerminalWidget does not work in Gtk4 as it is not an ancestor of SettingsPopover which needs to use them.