### PR TITLE
Gtk4 Prep - SettingsPopover - call terminal zoom functions directly

### DIFF
--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -6,9 +6,9 @@
 public sealed class Terminal.SettingsPopover : Gtk.Popover {
     public signal void show_theme_editor ();
 
-    public Vte.Terminal? terminal {
+    public TerminalWidget? terminal {
         owned get {
-            return terminal_binding.source as Vte.Terminal;
+            return terminal_binding.source as TerminalWidget;
         }
 
         set {
@@ -40,7 +40,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom out")
             )
         };
-        zoom_out_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_OUT);
+        zoom_out_button.clicked.connect (() => {terminal.decrease_font_size ();});
 
         var zoom_default_button = new Gtk.Button () {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -48,7 +48,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Default zoom level")
             )
         };
-        zoom_default_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_DEFAULT);
+        zoom_default_button.clicked.connect (() => {terminal.default_font_size ();});
 
         var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic") {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -56,7 +56,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom in")
             )
         };
-        zoom_in_button.set_detailed_action_name (TerminalWidget.ACTION_ZOOM_IN);
+        zoom_in_button.clicked.connect (() => {terminal.increase_font_size ();});
 
         var font_size_box = new Gtk.Box (HORIZONTAL, 0) {
             homogeneous = true,

--- a/src/Widgets/SettingsPopover.vala
+++ b/src/Widgets/SettingsPopover.vala
@@ -40,7 +40,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom out")
             )
         };
-        zoom_out_button.clicked.connect (() => {terminal.decrease_font_size ();});
+        zoom_out_button.clicked.connect (() => terminal.decrease_font_size ());
 
         var zoom_default_button = new Gtk.Button () {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -48,7 +48,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Default zoom level")
             )
         };
-        zoom_default_button.clicked.connect (() => {terminal.default_font_size ();});
+        zoom_default_button.clicked.connect (() => terminal.default_font_size ());
 
         var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic") {
             tooltip_markup = Granite.markup_accel_tooltip (
@@ -56,7 +56,7 @@ public sealed class Terminal.SettingsPopover : Gtk.Popover {
                 _("Zoom in")
             )
         };
-        zoom_in_button.clicked.connect (() => {terminal.increase_font_size ();});
+        zoom_in_button.clicked.connect (() => terminal.increase_font_size ());
 
         var font_size_box = new Gtk.Box (HORIZONTAL, 0) {
             homogeneous = true,

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -282,6 +282,7 @@ namespace Terminal {
             select_all_action.activate.connect (select_all);
             action_group.add_action (select_all_action);
 
+            //TODO In Gtk4 replace action with `add_binding_signal ()``
             var zoom_action = new GLib.SimpleAction ("zoom", VariantType.STRING);
             zoom_action.activate.connect ((p) => {
                 switch ((string) p) {
@@ -292,7 +293,7 @@ namespace Terminal {
                         decrease_font_size ();
                         break;
                     case "default":
-                        font_scale = 1.0;
+                        default_font_size ();
                         break;
                 }
             });
@@ -712,6 +713,10 @@ namespace Terminal {
 
         protected override void decrease_font_size () {
             font_scale -= 0.1;
+        }
+
+        public void default_font_size () {
+            font_scale = 1.0;
         }
 
         public bool is_init_complete () {


### PR DESCRIPTION
In Gtk4, the terminal zoom actions will be lost (replaced with `add_binding_signal ()` to provide keyboard shortcuts for zooming).  We do not need to use them in SettingsPopover as we already have a reference to the current terminal.