### PR TITLE
Enhance unsafe detection

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -534,9 +534,9 @@ namespace Terminal {
                     string? warn_text = null;
                     text._strip ();
 
-                    if ("\n" in text) {
+                    if ("\n" in text || "&" in text || "|" in text || ";" in text ) {
                         warn_text = _("The pasted text may contain multiple commands");
-                    } else if ("sudo" in text || "doas" in text) {
+                    } else if ("sudo " in text || "doas " in text || "run0 " in text || "pkexec " in text || "su " in text) {
                         warn_text = _("The pasted text may be trying to gain administrative access");
                     }
 


### PR DESCRIPTION
Not the cleanest. Can always define "more" dangerous behaviours, depends how much we want to get in the weeds. I need to learn more vala

contains:
Multiple commands: as oneliners chained with ";", "||", "|", "&&", "&"

Admin commands: run0, su, pkexec, who serve similar purpose to sudo and doas. "su -" can do a lot too
Add a space, to avoid false flag if say, it is a word like "visual" that has "su" in it. A command needs a space after it.

Following #799 thought its too a minute change to bug anyone