### PR TITLE
TerminalWidget: Fix non administrative commands not being pasted

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -547,6 +547,8 @@ namespace Terminal {
                         });
 
                         dialog.present ();
+                    } else {
+                        feed_child (text.data);
                     }
                 } else {
                     feed_child (text.data);


### PR DESCRIPTION
Fix a regression from #794 that non administrative commands like `apt list --installed` no longer pasted.