### PR TITLE
Drop dead feature that disables unsafe paste warning while Terminal opens

### DIFF
--- a/src/Dialogs/UnsafePasteDialog.vala
+++ b/src/Dialogs/UnsafePasteDialog.vala
@@ -42,19 +42,11 @@ public class Terminal.UnsafePasteDialog : Granite.MessageDialog {
 
         var ignore_button = (Gtk.Button) add_button (_("Paste Anyway"), Gtk.ResponseType.ACCEPT);
         ignore_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        ignore_button.clicked.connect (on_ignore);
 
         set_default_response (Gtk.ResponseType.CANCEL);
 
         Terminal.Application.settings.bind (
             "unsafe-paste-alert", show_protection_warnings, "active", SettingsBindFlags.DEFAULT
         );
-    }
-
-    private void on_ignore () {
-        var terminal_window = get_transient_for ();
-        if (terminal_window is MainWindow) {
-            ((MainWindow) terminal_window).unsafe_ignored = true;
-        }
     }
 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -54,7 +54,6 @@ namespace Terminal {
         private const int MAXIMIZED = 1;
         private const int FULLSCREEN = 2;
 
-        public bool unsafe_ignored;
         public bool focus_restored_tabs { get; construct; default = true; }
         public bool recreate_tabs { get; construct; default = true; }
         public Menu context_menu_model { get; private set; }

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -526,10 +526,7 @@ namespace Terminal {
         // Check pasted and dropped text before feeding to child;
         private void validated_feed (string? text) {
             if (text != null && text.validate ()) {
-                unowned var toplevel = (MainWindow) get_toplevel ();
-                if (!toplevel.unsafe_ignored &&
-                    Application.settings.get_boolean ("unsafe-paste-alert")) {
-
+                if (Application.settings.get_boolean ("unsafe-paste-alert")) {
                     string? warn_text = null;
                     if ("\n" in text) {
                         warn_text = _("The pasted text may contain multiple commands");
@@ -538,11 +535,11 @@ namespace Terminal {
                     }
 
                     if (warn_text != null) {
+                        unowned var toplevel = (MainWindow) get_toplevel ();
                         var dialog = new UnsafePasteDialog (toplevel, warn_text, text.strip ());
                         dialog.response.connect ((res) => {
                             dialog.destroy ();
                             if (res == Gtk.ResponseType.ACCEPT) {
-                                toplevel.unsafe_ignored = true;
                                 feed_child (text.data);
                             }
                         });

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -542,6 +542,7 @@ namespace Terminal {
                         dialog.response.connect ((res) => {
                             dialog.destroy ();
                             if (res == Gtk.ResponseType.ACCEPT) {
+                                toplevel.unsafe_ignored = true;
                                 feed_child (text.data);
                             }
                         });


### PR DESCRIPTION
This PR removes the dead feature that disables unsafe paste warning while Terminal opens.

---

As far as reading the code of UnsafePasteDialog.vala, this dialog shouldn't appear again while the current Terminal window is alive once if the user clicks "Paste Anyway". However, this isn't working at the moment because the clicked event of the "Paste Anyway" button is treated as a response of UnsafePasteDialog and the `on_ignore ()` method is not triggered at all.

On the other hand, however, I also feels the current "unintentional" behavior that this dialog always appears when pasting administrative commands makes sense too. We can now toggle unsafe paste warning from preferences menu,
so this dead feature is useless. Therefore, I just dropped the dead feature instead of correctly implementing it in favor of current "unintentional" behavior.