### PR TITLE
TerminalWidget: Refactor validated_feed to avoid nested conditions

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -547,6 +547,8 @@ namespace Terminal {
                         });
 
                         dialog.present ();
+                    } else {
+                        feed_child (text.data);
                     }
                 } else {
                     feed_child (text.data);


### PR DESCRIPTION
The current code of `validated_feed ()` is difficult to recognize routes for each condition, so make it more readable by avoiding nested conditions.