### PR TITLE
Add tab to new window created with <Shift><Ctrl>N

### DIFF
--- a/data/io.elementary.terminal.appdata.xml.in
+++ b/data/io.elementary.terminal.appdata.xml.in
@@ -73,6 +73,7 @@
         </ul>
       </description>
       <issues>
+        <issue url="https://github.com/elementary/terminal/issues/814">New window created with Ctrl Shift N has zero tabs and is transparent</issue>
         <issue url="https://github.com/elementary/terminal/issues/812">Notifications are not withdrawn</issue>
         <issue url="https://github.com/elementary/terminal/issues/806">Fails to build in Launchpad due to tests</issue>
         <issue url="https://github.com/elementary/terminal/issues/793">Drag-drop command bypasses sudo warning</issue>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -258,12 +258,19 @@ public class Terminal.Application : Gtk.Application {
 
         var new_window_action = new SimpleAction ("new-window", null);
         new_window_action.activate.connect (() => {
+            string dir = Environment.get_home_dir ();
+            if (active_window != null) {
+                dir = ((MainWindow)active_window).current_terminal.current_working_directory;
+            }
+
             var new_window = new MainWindow (this, active_window == null);
-            var width = saved_state.get_int ("window-width");
-            var height = saved_state.get_int ("window-height");
-            new_window.set_size_request (width, height);
             new_window.present ();
-            new_window.add_tab_with_working_directory (Environment.get_current_dir ());
+            new_window.set_size_request (
+                saved_state.get_int ("window-width"),
+                saved_state.get_int ("window-height")
+            );
+
+            new_window.add_tab_with_working_directory (dir);
         });
 
         var quit_action = new SimpleAction ("quit", null);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,6 +4,9 @@
  */
 
 public class Terminal.Application : Gtk.Application {
+    public const int MINIMUM_WIDTH = 600;
+    public const int MINIMUM_HEIGHT = 400;
+
     private string commandline = "\0"; // used to temporary hold the argument to --commandline=
     private uint dbus_id = 0;
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -4,9 +4,6 @@
  */
 
 public class Terminal.Application : Gtk.Application {
-    public int minimum_width;
-    public int minimum_height;
-
     private string commandline = "\0"; // used to temporary hold the argument to --commandline=
     private uint dbus_id = 0;
 
@@ -258,7 +255,12 @@ public class Terminal.Application : Gtk.Application {
 
         var new_window_action = new SimpleAction ("new-window", null);
         new_window_action.activate.connect (() => {
-            new MainWindow (this, active_window == null).present ();
+            var new_window = new MainWindow (this, active_window == null);
+            var width = saved_state.get_int ("window-width");
+            var height = saved_state.get_int ("window-height");
+            new_window.set_size_request (width, height);
+            new_window.present ();
+            new_window.add_tab_with_working_directory (Environment.get_current_dir ());
         });
 
         var quit_action = new SimpleAction ("quit", null);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -245,7 +245,7 @@ namespace Terminal {
             Application.settings_sys.changed["monospace-font-name"].connect (update_font);
             Application.settings.changed["font"].connect (update_font);
 
-            set_size_request (app.minimum_width, app.minimum_height);
+            set_size_request (Application.MINIMUM_WIDTH, Application.MINIMUM_HEIGHT);
 
             show_all ();
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -256,9 +256,14 @@ namespace Terminal {
             delete_event.connect (on_delete_event);
         }
 
-        public void add_tab_with_working_directory (string? directory, string? command = null, bool create_new_tab = false) {
-            /* This requires all restored tabs to be initialized first so that the shell location is available */
-            /* Do not add a new tab if location is already open in existing tab */
+        public void add_tab_with_working_directory (
+            string? directory,
+            string? command = null,
+            bool create_new_tab = false
+        ) {
+            /* This requires all restored tabs to be initialized first so that
+             * the shell location is available.
+             * Do not add a new tab if location is already open in existing tab */
             string? location = null;
             if (directory == null || directory == "") {
                 if (notebook.n_pages == 0 || command != null || create_new_tab) { //Ensure at least one tab
@@ -707,12 +712,6 @@ namespace Terminal {
             } else {
                 terminal_widget.font_scale = Terminal.Application.saved_state.get_double ("zoom");
             }
-
-            int minimum_width = terminal_widget.calculate_width (80) / 2;
-            int minimum_height = terminal_widget.calculate_height (24) / 2;
-            set_size_request (minimum_width, minimum_height);
-            app.minimum_width = minimum_width;
-            app.minimum_height = minimum_height;
 
             if (focus) {
                 notebook.selected_page = tab;


### PR DESCRIPTION
Fixes #814 

 - New tab added in Application `new-window` action handler
 - New window follows size of current window
 - New tab follows current working directory of current window


There is scope for improving consistency and DRYing with code handling new windows created by dragging tabs, from the dock and from the commandline but that is left for now.

Code potentially changing the window size by adding a tab was removed as it did not seem appropriate. The window size is already controlled by settings, the user and the window manager.