### PR TITLE
Fix clear and reset actions when ongoing foreground process

### DIFF
--- a/src/Dialogs/ForegroundProcessDialog.vala
+++ b/src/Dialogs/ForegroundProcessDialog.vala
@@ -20,42 +20,21 @@
 public class Terminal.ForegroundProcessDialog : Granite.MessageDialog {
     public string button_label { get; construct; }
 
-    public ForegroundProcessDialog (MainWindow parent) {
+    public ForegroundProcessDialog (
+        MainWindow parent,
+        string primary_text,
+        string button_label
+    ) {
         Object (
             transient_for: parent,
-            primary_text: _("Are you sure you want to close this tab?"),
-            secondary_text:
-                _("There is an active process on this tab.") + " " +
-                _("If you close it, the process will end."),
-            buttons: Gtk.ButtonsType.CANCEL,
-            button_label: _("Close Tab")
-        );
-    }
-
-    public ForegroundProcessDialog.before_close (MainWindow parent) {
-        Object (
-            transient_for: parent,
-            primary_text: _("Are you sure you want to quit Terminal?"),
-            secondary_text:
-                _("There is an active process on this terminal.") + " " +
-                _("If you quit Terminal, the process will end."),
-            buttons: Gtk.ButtonsType.CANCEL,
-            button_label: _("Quit Terminal")
-        );
-    }
-
-    public ForegroundProcessDialog.before_tab_reload (MainWindow parent) {
-        Object (
-            transient_for: parent,
-            primary_text: _("Are you sure you want to reload this tab?"),
-            secondary_text:
-                _("There is an active process on this tab. If you reload it, the process will end."),
-            buttons: Gtk.ButtonsType.CANCEL,
-            button_label: _("Reload Tab")
+            primary_text: primary_text,
+            button_label: button_label,
+            buttons: Gtk.ButtonsType.CANCEL
         );
     }
 
     construct {
+        secondary_text = _("There is an active process on this tab. If you continue, the process will end.");
         image_icon = new ThemedIcon ("dialog-warning");
 
         var close_button = add_button (button_label, Gtk.ResponseType.ACCEPT);

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -529,14 +529,15 @@ namespace Terminal {
         }
 
         private void action_clear_screen () {
-            if (confirm_kill_fg_process (
-                _("Are you sure you want to clear the screen?"),
-                _("Clear Screen"))
-            ) {
-                // Should we clear scrollback too?
-                // We know there is no foreground process so we can just feed the command in
-                feed_child ("clear -x\n".data);
+            if (has_foreground_process ()) {
+                // We cannot guarantee the terminal is left in sensible state if we 
+                // kill foreground process so ignore clear screen request
+                return;
             }
+
+            // We keep the scrollback history, just clear the screen
+            // We know there is no foreground process so we can just feed the command in
+            feed_child ("clear -x\n".data);
         }
 
         private void action_reset () {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -534,7 +534,8 @@ namespace Terminal {
                 _("Clear Screen"))
             ) {
                 // Should we clear scrollback too?
-                run_program ("clear -x", null);
+                // We know there is no foreground process so we can just feed the command in
+                feed_child ("clear -x\n".data);
             }
         }
 
@@ -544,7 +545,8 @@ namespace Terminal {
                 _("Reset"))
             ) {
                 // This also clears the screen and the scrollback
-                run_program ("reset", null);
+                // We know there is no foreground process so we can just feed the command in
+                feed_child ("reset\n".data);
             }
         }
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -74,8 +74,8 @@ namespace Terminal {
 
         public const string[] ACCELS_COPY = { "<Control><Shift>C", null };
         public const string[] ACCELS_COPY_OUTPUT = { "<Alt>C", null };
-        public const string[] ACCELS_CLEAR_SCREEN = { "<Control>L", null };
-        public const string[] ACCELS_RESET = { "<Control>K", null };
+        public const string[] ACCELS_CLEAR_SCREEN = { "<Control><Shift>L", null };
+        public const string[] ACCELS_RESET = { "<Control><Shift>K", null };
         public const string[] ACCELS_PASTE = { "<Control><Shift>V", null };
         public const string[] ACCELS_RELOAD = { "<Control><Shift>R", "<Ctrl>F5", null };
         public const string[] ACCELS_SCROLL_TO_COMMAND = { "<Alt>Up", null };


### PR DESCRIPTION
Fixes #819 
Fixes #820 

 - [x] Confirm kill foreground process before reset action
 - [x] Ignore clear screen action if there is a foreground process 
 - [x] Change hotkeys for clear and reset actions so do not clash with `nano`
 - [x] DRY related code  

Because we cannot guarantee the state of the terminal if the foreground process is killed (see #824 ) the clear action is ignored when a foreground process is running. Resetting the terminal is OK as the terminal state is reset to something sensible.

There is little difference between the "Reload" action and the "Reset" action. The former starts a new shell process whereas the latter resets the existing one.  Not sure if we need both. Only the latter is shown in the context menu atm.