### PR TITLE
Bring back autohide feature from #832

### DIFF
--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -10,6 +10,12 @@ public class Terminal.TerminalView : Gtk.Box {
         URI_LIST
     }
 
+    public enum TabBarBehavior {
+        ALWAYS = 0,
+        SINGLE = 1,
+        NEVER = 2
+    }
+
     public signal void new_tab_requested ();
     public signal void tab_duplicated (Hdy.TabPage page);
 
@@ -71,8 +77,9 @@ public class Terminal.TerminalView : Gtk.Box {
             use_popover = false,
         };
 
+        var tab_bar_behavior = (TabBarBehavior)Application.settings.get_enum ("tab-bar-behavior");
         tab_bar = new Hdy.TabBar () {
-            autohide = false,
+            autohide = (tab_bar_behavior == TabBarBehavior.SINGLE), // This is <value value="1" nick="Hide When Single Tab"/>
             expand_tabs = false,
             inverted = true,
             start_action_widget = new_tab_button,


### PR DESCRIPTION
Bring back autohide feature from #832

Terminal v 6.2.0 had an option to hide tab bar completely or when there is only one tab is present. All the options could not be re-implemented, but we can re-intorduce hide-when-single

- keep old  gschema values for existing user settings and guides compatibility
- local changes and borrow the enum from Granite