### PR TITLE
Cycle tabs with Ctrl+Tab

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -482,7 +482,7 @@ namespace Terminal {
                     if (MOD1_MASK in modifiers
                     && Application.settings.get_boolean ("alt-changes-tab")
                     && notebook.n_pages > 1) {
-                        notebook.selected_page = notebook.tab_view.get_nth_page ((int)notebook.n_pages - 1);
+                        notebook.selected_page = notebook.tab_view.get_nth_page (notebook.n_pages - 1);
                         return true;
                     }
                     break;
@@ -645,7 +645,7 @@ namespace Terminal {
         private void open_tabs () {
             string[] tabs = {};
             double[] zooms = {};
-            uint focus = 0;
+            int focus = 0;
             var default_zoom = Application.saved_state.get_double ("zoom"); //Range set in settings 0.25 - 4.0
 
             if (Granite.Services.System.history_is_enabled () &&
@@ -715,7 +715,7 @@ namespace Terminal {
             }
 
             if (focus_restored_tabs) {
-                var tab = notebook.tab_view.get_nth_page ((int)(focus.clamp (0, notebook.n_pages - 1)));
+                var tab = notebook.tab_view.get_nth_page (focus.clamp (0, notebook.n_pages - 1));
                 notebook.selected_page = tab;
             }
         }
@@ -724,7 +724,7 @@ namespace Terminal {
             string location,
             string? program = null,
             bool focus = true,
-            int pos = (int)notebook.n_pages
+            int pos = notebook.n_pages
         ) {
 
             /*

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1005,11 +1005,11 @@ namespace Terminal {
         }
 
         private void action_next_tab () {
-            notebook.tab_view.select_next_page ();
+            notebook.cycle_tabs (FORWARD);
         }
 
         private void action_previous_tab () {
-            notebook.tab_view.select_previous_page ();
+            notebook.cycle_tabs (BACK);
         }
 
         void action_move_tab_right () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -999,7 +999,7 @@ namespace Terminal {
 
             var pos = notebook.tab_menu_target != null ?
                       notebook.tab_view.get_page_position (notebook.tab_menu_target) + 1 :
-                      (int)notebook.n_pages;
+                      notebook.n_pages;
 
             new_tab (term.get_shell_location (), null, true, pos);
         }

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -13,7 +13,7 @@ public class Terminal.TerminalView : Gtk.Box {
     public signal void new_tab_requested ();
     public signal void tab_duplicated (Hdy.TabPage page);
 
-    public uint n_pages {
+    public int n_pages {
         get {
             return tab_view.n_pages;
         }

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -165,6 +165,18 @@ public class Terminal.TerminalView : Gtk.Box {
         tab_view.selected_page = target;
     }
 
+    public void cycle_tabs (Hdy.NavigationDirection direction) {
+        var pos = (int) tab_view.get_page_position (selected_page);
+        pos = direction == FORWARD ? pos + 1 : pos - 1;
+        if (pos == n_pages) {
+            pos = 0;
+        } else if (pos < 0) {
+            pos = (int) n_pages - 1;
+        }
+
+        selected_page = tab_view.get_nth_page (pos);
+    }
+
     public void transfer_tab_to_new_window () {
         var target = tab_menu_target ?? tab_view.selected_page;
 

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -166,7 +166,7 @@ public class Terminal.TerminalView : Gtk.Box {
     }
 
     public void cycle_tabs (Hdy.NavigationDirection direction) {
-        var pos = (int) tab_view.get_page_position (selected_page);
+        var pos = tab_view.get_page_position (selected_page);
         pos = direction == FORWARD ? pos + 1 : pos - 1;
         if (pos == n_pages) {
             pos = 0;

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -168,11 +168,7 @@ public class Terminal.TerminalView : Gtk.Box {
     public void cycle_tabs (Hdy.NavigationDirection direction) {
         var pos = tab_view.get_page_position (selected_page);
         pos = direction == FORWARD ? pos + 1 : pos - 1;
-        if (pos == n_pages) {
-            pos = 0;
-        } else if (pos < 0) {
-            pos = (int) n_pages - 1;
-        }
+        pos = (pos + n_pages) % n_pages;
 
         selected_page = tab_view.get_nth_page (pos);
     }

--- a/src/tests/Application.vala
+++ b/src/tests/Application.vala
@@ -145,14 +145,14 @@ namespace Terminal.Test.Application {
             option ("{'new-tab':<true>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.notebook.n_pages;
+                var n_tabs = window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 2);
             });
 
             option ("{'new-tab':<false>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.notebook.n_pages;
+                var n_tabs = window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 1);
             });
         });
@@ -176,7 +176,7 @@ namespace Terminal.Test.Application {
             option ("{'execute':<[b'%s']>}".printf (string.joinv ("',b'", execute)), "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.notebook.n_pages;
+                var n_tabs = window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 5); // include the guaranted extra tab
             });
 
@@ -184,7 +184,7 @@ namespace Terminal.Test.Application {
             option ("{'execute':<[b'',b'',b'']>}", "@a{sv} {}", () => {
                 unowned var window = (MainWindow) application.active_window;
                 assert_nonnull (window);
-                var n_tabs = (int) window.notebook.n_pages;
+                var n_tabs = window.notebook.n_pages;
                 assert_cmpint (n_tabs, CompareOperator.EQ, 1);
             });
         });


### PR DESCRIPTION
Fixes #834 

Rather than use the native Hdy.TabView select_next_page ()  and select_previous_page () functions, which do not cycle, a custom function is used.
