### PR TITLE
Change tab label to name of foreground child process

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -770,11 +770,10 @@ namespace Terminal {
                 terminal_widget.run_program (program, location);
             }
 
-            check_for_tabs_with_same_name ();
             save_opened_terminals (true, true);
 
             connect_terminal_signals (terminal_widget);
-
+            check_for_tabs_with_same_name ();
             return terminal_widget;
         }
 
@@ -1156,8 +1155,7 @@ namespace Terminal {
             return;
         }
 
-        private void on_terminal_cwd_changed (TerminalWidget src, string cwd) {
-            src.tab.tooltip = cwd;
+        private void on_terminal_cwd_changed () {
             check_for_tabs_with_same_name (); // Also sets window title
             save_opened_terminals (true, false);
         }

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -806,11 +806,24 @@ namespace Terminal {
             }
         }
 
+        private string get_shell_name () {
+            return (Path.get_basename (get_pid_cmdline (child_pid)));
+        }
+
         public string get_pid_cmdline (int pid) {
             try {
                 string cmdline;
                 GLib.FileUtils.get_contents ("/proc/%d/cmdline".printf (pid), out cmdline);
                 return cmdline;
+            } catch (GLib.Error e) {
+                return "";
+            }
+        }
+
+        public string get_pid_exe_name (int pid) {
+            try {
+                var exe = GLib.FileUtils.read_link ("/proc/%d/exe".printf (pid));
+                return Path.get_basename (exe);
             } catch (GLib.Error e) {
                 return "";
             }
@@ -982,12 +995,12 @@ namespace Terminal {
                     if (cwd != current_working_directory) {
                         update_current_working_directory (cwd);
                     }
-
+warning ("shell name %s", get_shell_name ());
                     int pid;
                     try_get_foreground_pid (out pid);
                     if (pid != fg_pid) {
-                        var cmdline = get_pid_cmdline (pid);
-                        foreground_process_changed (cmdline);
+                        var name = get_pid_exe_name (pid);
+                        foreground_process_changed (name);
                         fg_pid = pid;
                     }
 

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -727,8 +727,6 @@ namespace Terminal {
             } catch (Error e) {
                 warning (e.message);
             }
-
-            update_current_working_directory (dir);
         }
 
         public void run_program (string _program_string, string? working_directory) {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -806,20 +806,6 @@ namespace Terminal {
             }
         }
 
-        private string get_shell_name () {
-            return (Path.get_basename (get_pid_cmdline (child_pid)));
-        }
-
-        public string get_pid_cmdline (int pid) {
-            try {
-                string cmdline;
-                GLib.FileUtils.get_contents ("/proc/%d/cmdline".printf (pid), out cmdline);
-                return cmdline;
-            } catch (GLib.Error e) {
-                return "";
-            }
-        }
-
         public string get_pid_exe_name (int pid) {
             try {
                 var exe = GLib.FileUtils.read_link ("/proc/%d/exe".printf (pid));
@@ -995,7 +981,7 @@ namespace Terminal {
                     if (cwd != current_working_directory) {
                         update_current_working_directory (cwd);
                     }
-warning ("shell name %s", get_shell_name ());
+
                     int pid;
                     try_get_foreground_pid (out pid);
                     if (pid != fg_pid) {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -798,7 +798,7 @@ namespace Terminal {
             }
         }
 
-        public string get_pid_name (int pid) {
+        public string get_pid_cmdline (int pid) {
             try {
                 string cmdline;
                 GLib.FileUtils.get_contents ("/proc/%d/cmdline".printf (pid), out cmdline);
@@ -962,7 +962,7 @@ namespace Terminal {
             int pid;
             try_get_foreground_pid (out pid);
             if (pid != fg_pid) {
-                var cmdline = get_pid_name (pid);
+                var cmdline = get_pid_cmdline (pid);
                 foreground_process_changed (cmdline);
                 fg_pid = pid;
             }


### PR DESCRIPTION
Partially fixes #698 
Partially fixes #646

When a foreground process is running in a tab, the tab label now shows information about the running process.

To be decided - what information should be shown? Currently it is the basename of the `exe` file from the `/proc/<pid>` directory.

When the foreground process is `screen`, it proved impossible (?) to get the working directory of the screen window currently showing (it show more than one anyway). It is possible to edit the `screenrc` config file to show screen status info in the headerbar and/or within its own windows.