### PR TITLE
Center the title, set min searchentry width

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -332,8 +332,12 @@ namespace Terminal {
             title_label.get_style_context ().add_class (Gtk.STYLE_CLASS_TITLE);
 
             title_stack = new Gtk.Stack () {
-                transition_type = Gtk.StackTransitionType.SLIDE_UP_DOWN
+                transition_type = Gtk.StackTransitionType.SLIDE_UP_DOWN,
+                hhomogeneous = false,
+                hexpand = false
             };
+
+            search_toolbar.width_request = 300;
             title_stack.add (title_label);
             title_stack.add (search_toolbar);
             // Must show children before visible_child can be set


### PR DESCRIPTION
Fixes #840, with side-effects

The cause of the issue is that the custom title is set to horizontally expand so the headerbar cannot center it on itself.

There is no simple fix to this issue while keeping the same appearance of the search widget as far as I can find. As a compromise, the search widget now has a fixed width which should be sufficient for most search terms and is centered in the headerbar.

BEFORE
![Screenshot from 2025-01-03 12 14 33](https://github.com/user-attachments/assets/d6a4ee66-3134-45aa-83ed-f7cd779c119c)

![Screenshot from 2025-01-03 12 14 42](https://github.com/user-attachments/assets/d9b5f83a-ce82-4d6e-8792-6db9607cb394)


AFTER
![Screenshot from 2025-01-03 12 13 54](https://github.com/user-attachments/assets/0ade2704-255c-40ef-85b3-a7e2cd96ce68)

![Screenshot from 2025-01-03 12 14 04](https://github.com/user-attachments/assets/7ec152b4-96b1-448f-a7db-43b6c9ab59d1)

