### PR TITLE
Remove tab process-finished icon on select

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,6 +14,8 @@ public class Terminal.Application : Gtk.Application {
     public static GLib.Settings settings;
     public static GLib.Settings settings_sys;
 
+    public const string PROCESS_COMPLETED_ICON_NAME = "process-completed-symbolic";
+
     public bool is_testing { get; set construct; }
 
     private static Themes themes;
@@ -186,7 +188,7 @@ public class Terminal.Application : Gtk.Application {
             }
 
             var process_string = _("Process completed");
-            var process_icon = new ThemedIcon ("process-completed-symbolic");
+            var process_icon = new ThemedIcon (PROCESS_COMPLETED_ICON_NAME);
             if (exit_status != 0) {
                 process_string = _("Process exited with errors");
                 process_icon = new ThemedIcon ("process-error-symbolic");

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -14,9 +14,6 @@ public class Terminal.Application : Gtk.Application {
     public static GLib.Settings settings;
     public static GLib.Settings settings_sys;
 
-    public const string PROCESS_COMPLETED_ICON_NAME = "process-completed-symbolic";
-    public const string PROCESS_ERROR_ICON_NAME = "process-error-symbolic";
-
     public bool is_testing { get; set construct; }
 
     private static Themes themes;
@@ -178,10 +175,10 @@ public class Terminal.Application : Gtk.Application {
             }
 
             var process_string = _("Process completed");
-            var process_icon = new ThemedIcon (PROCESS_COMPLETED_ICON_NAME);
+            var process_icon = new ThemedIcon ("process-completed-symbolic");
             if (exit_status != 0) {
                 process_string = _("Process exited with errors");
-                process_icon = new ThemedIcon (PROCESS_ERROR_ICON_NAME);
+                process_icon = new ThemedIcon ("process-error-symbolic");
             }
 
             if (terminal != terminal.main_window.current_terminal) {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -15,6 +15,7 @@ public class Terminal.Application : Gtk.Application {
     public static GLib.Settings settings_sys;
 
     public const string PROCESS_COMPLETED_ICON_NAME = "process-completed-symbolic";
+    public const string PROCESS_ERROR_ICON_NAME = "process-error-symbolic";
 
     public bool is_testing { get; set construct; }
 
@@ -180,7 +181,7 @@ public class Terminal.Application : Gtk.Application {
             var process_icon = new ThemedIcon (PROCESS_COMPLETED_ICON_NAME);
             if (exit_status != 0) {
                 process_string = _("Process exited with errors");
-                process_icon = new ThemedIcon ("process-error-symbolic");
+                process_icon = new ThemedIcon (PROCESS_ERROR_ICON_NAME);
             }
 
             if (terminal != terminal.main_window.current_terminal) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -396,6 +396,7 @@ namespace Terminal {
 
                 title = term.window_title != "" ? term.window_title
                                                 : term.current_working_directory;
+
                 if (term.tab == null) {
                     // Happens on opening window - ignore
                     return;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -404,6 +404,10 @@ namespace Terminal {
                 title = term.window_title != "" ? term.window_title
                                                 : term.current_working_directory;
                 term.grab_focus ();
+                if (term.tab == null) {
+                    // Happens on opening window - ignore
+                    return;
+                }
                 //TODO Check that icon is "process-completed-symbolic"
                 // if `tab.icon` is ever used for something that should remain
                 term.tab.icon = null;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -401,10 +401,12 @@ namespace Terminal {
                     return;
                 }
 
-
                 title = term.window_title != "" ? term.window_title
                                                 : term.current_working_directory;
                 term.grab_focus ();
+                //TODO Check that icon is "process-completed-symbolic"
+                // if `tab.icon` is ever used for something that should remain
+                term.tab.icon = null;
             });
 
             var overlay = new Gtk.Overlay () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -400,9 +400,13 @@ namespace Terminal {
                     // Happens on opening window - ignore
                     return;
                 }
-                //TODO Check that icon is "process-completed-symbolic"
-                // if `tab.icon` is ever used for something that should remain
-                term.tab.icon = null;
+
+                if (term.tab.icon is ThemedIcon) {
+                    var icon = (ThemedIcon) term.tab.icon;
+                    if (icon.names[0] == Terminal.Application.PROCESS_COMPLETED_ICON_NAME) {
+                        term.tab.icon = null;
+                    }
+                }
 
                 // Need to wait for default handler to run before focusing
                 Idle.add (() => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -401,12 +401,7 @@ namespace Terminal {
                     return;
                 }
 
-                if (term.tab.icon is ThemedIcon) {
-                    var icon = (ThemedIcon) term.tab.icon;
-                    if (icon.names[0] == Terminal.Application.PROCESS_COMPLETED_ICON_NAME) {
-                        term.tab.icon = null;
-                    }
-                }
+                term.tab.icon = null; // Assume only process icons are set
 
                 // Need to wait for default handler to run before focusing
                 Idle.add (() => {


### PR DESCRIPTION
Fixes #831

The "process-finished" icon is only added if the tabpage is not selected when the process finishes so we only need remove it when the tabpage is selected.