### PR TITLE
Metainfo: add 7.0.0 release notes

### DIFF
--- a/data/io.elementary.terminal.appdata.xml.in
+++ b/data/io.elementary.terminal.appdata.xml.in
@@ -53,6 +53,19 @@
   <update_contact>contact_AT_elementary.io</update_contact>
 
   <releases>
+    <release version="7.0.0" date="2025-02-12" urgency="medium">
+      <description>
+        <p>Other updates:</p>
+        <ul>
+          <li>Translation updates</li>
+        </ul>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/terminal/issues/845">Terminal Tabs require 3 tab key presses to get focus</issue>
+        <issue url="https://github.com/elementary/terminal/issues/853">Tab that is dragged out of window does not close</issue>
+      </issues>
+    </release>
+
     <release version="6.3.1" date="2025-01-08" urgency="medium">
       <description>
         <p>Other updates:</p>


### PR DESCRIPTION
bumping to 7 because we're no longer releasing terminal for OS 6.x