### PR TITLE
Fix incorrect line breaks when pasting/dropping into foreground processes

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -553,12 +553,12 @@ namespace Terminal {
 
         protected override void paste_clipboard () {
             clipboard.request_text ((clipboard, text) => {
-                validated_feed (text);
+                validated_paste (text);
             });
         }
 
         // Check pasted and dropped text before feeding to child;
-        private void validated_feed (string? text) {
+        private void validated_paste (string? text) {
             // Do nothing when text is invalid
             if (text == null || !text.validate ()) {
                 return;
@@ -566,7 +566,7 @@ namespace Terminal {
 
             // No user interaction because of user's preference
             if (!Application.settings.get_boolean ("unsafe-paste-alert")) {
-                feed_child (text.data);
+                paste_text (text);
                 return;
             }
 
@@ -575,7 +575,7 @@ namespace Terminal {
 
             // No user interaction for safe commands
             if (Utils.is_safe_paste (text, out warn_text)) {
-                feed_child (text.data);
+                paste_text (text);
                 return;
             }
 
@@ -585,7 +585,7 @@ namespace Terminal {
             dialog.response.connect ((res) => {
                 dialog.destroy ();
                 if (res == Gtk.ResponseType.ACCEPT) {
-                    feed_child (text.data);
+                    paste_text (text);
                 }
             });
 
@@ -847,7 +847,7 @@ namespace Terminal {
                 case DropTargets.STRING:
                 case DropTargets.TEXT:
                     var text = selection_data.get_text ();
-                    validated_feed (text);
+                    validated_paste (text);
                     break;
             }
         }


### PR DESCRIPTION
Fixes #861 

Using `paste_text ()` instead of `feed_child ()` applies some extra processing that fixes the issue.  The pasted text does not need to have come from the clipboard - it works as well with dropped text.