### PR TITLE
MainWindow: GTK4 prep

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -152,8 +152,6 @@ namespace Terminal {
                 app.set_accels_for_action (ACTION_PREFIX + action, accels_array);
             }
 
-            set_visual (Gdk.Screen.get_default ().get_rgba_visual ());
-
             title = TerminalWidget.DEFAULT_LABEL;
 
             clipboard = Gtk.Clipboard.get (Gdk.Atom.intern ("CLIPBOARD", false));

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,20 +1,7 @@
 /*
-* Copyright (c) 2011-2022 elementary, Inc. (https://elementary.io)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU Lesser General Public
-* License version 3, as published by the Free Software Foundation.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU Lesser General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2011-2025 elementary, Inc. (https://elementary.io)
+ */
 
 namespace Terminal {
     public class MainWindow : Hdy.Window {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -420,7 +420,7 @@ namespace Terminal {
             box.add (header);
             box.add (overlay);
 
-            add (box);
+            child = box;
             get_style_context ().add_class ("terminal-window");
 
             bind_property ("title", title_label, "label");


### PR DESCRIPTION
* Bump license header
* No more `decoration_layout_set` in GTK4
* Explicit expands
* Child property
* More accurate cast, no more `Gtk.Bin`
* ScrolledWindow doesn't take args in GTK4, so use vadjustment property
* Minimize use of Gtk.Clipboard functions that are going away
* Remove `set_visual`. This is I think really old stuff and it's not clear it even does anything for us in GTK3