### PR TITLE
MainWindow: Ellipsize the title label

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -317,7 +317,11 @@ namespace Terminal {
 
             search_toolbar = new Terminal.Widgets.SearchToolbar (this);
 
-            title_label = new Gtk.Label (title);
+            title_label = new Gtk.Label (title) {
+                wrap = false,
+                single_line_mode = true,
+                ellipsize = Pango.EllipsizeMode.END
+            };
             title_label.get_style_context ().add_class (Gtk.STYLE_CLASS_TITLE);
 
             title_stack = new Gtk.Stack () {


### PR DESCRIPTION
Makes sure to not resize the window when using a long command. Done the same as in Gtk.