### PR TITLE
Close tab when shell killed

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -323,7 +323,7 @@ public class Terminal.Application : Gtk.Application {
         } else if (options.lookup ("commandline", "^&ay", out command) && command != "\0") {
             window.add_tab_with_working_directory (working_directory, command, new_tab);
         } else if (new_tab || window.notebook.n_pages == 0) {
-            window.add_tab_with_working_directory (working_directory, null, new_tab);
+            window.add_tab_with_working_directory (working_directory, "", new_tab);
         }
 
         if (options.lookup ("minimized", "b", out minimized) && minimized) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -247,16 +247,16 @@ namespace Terminal {
         }
 
         public void add_tab_with_working_directory (
-            string? directory,
-            string? command = null,
+            string directory = "",
+            string command = "",
             bool create_new_tab = false
         ) {
 
             /* This requires all restored tabs to be initialized first so that
              * the shell location is available.
              * Do not add a new tab if location is already open in existing tab */
-            string? location = null;
-            if (directory == null || directory == "") {
+            string location = "";
+            if (directory.length == 0) {
                 if (notebook.n_pages == 0 || command != null || create_new_tab) { //Ensure at least one tab
                     new_tab ("", command);
                 }
@@ -267,7 +267,7 @@ namespace Terminal {
             }
 
             /* We can match existing tabs only if there is no command and create_new_tab == false */
-            if (command == null && !create_new_tab) {
+            if (command.length == 0 && !create_new_tab) {
                 var file = File.new_for_commandline_arg (location);
                 for (int pos = 0; pos < notebook.n_pages; pos++) {
                     var tab = notebook.tab_view.get_nth_page (pos);
@@ -376,6 +376,7 @@ namespace Terminal {
                     }
 
                     disconnect_terminal_signals (term);
+                    term.prepare_to_close ();
                 }
 
                 notebook.tab_view.close_page_finish (tab, confirmed);
@@ -703,7 +704,7 @@ namespace Terminal {
                 if (loc == "") {
                     focus--;
                 } else {
-                    var term = new_tab (loc, null, false);
+                    var term = new_tab (loc, "", false);
                     term.font_scale = zooms[index].clamp (
                         TerminalWidget.MIN_SCALE,
                         TerminalWidget.MAX_SCALE
@@ -721,7 +722,7 @@ namespace Terminal {
 
         private TerminalWidget new_tab (
             string location,
-            string? program = null,
+            string program = "",
             bool focus = true,
             int pos = notebook.n_pages
         ) {
@@ -758,7 +759,7 @@ namespace Terminal {
                 notebook.selected_page = tab;
             }
 
-            if (program == null) {
+            if (program.length == 0) {
                 /* Set up the virtual terminal */
                 if (location == "") {
                     terminal_widget.active_shell ();
@@ -796,11 +797,12 @@ namespace Terminal {
                 // TabView already removed tab - ignore signal
                 return;
             }
+
             if (!tw.killed) {
-                if (tw.program_string != null) {
+                if (tw.program_string.length > 0) {
                     /* If a program was running, do not close the tab so that output of program
                      * remains visible */
-                    tw.program_string = null;
+                    tw.program_string = "";
                     tw.active_shell (tw.current_working_directory);
                     check_for_tabs_with_same_name ();
                 } else {
@@ -948,7 +950,7 @@ namespace Terminal {
         }
 
         private void action_restore_closed_tab (GLib.SimpleAction action, GLib.Variant? param) {
-            new_tab (param.get_string (), null, true); //TODO Restore icon?
+            new_tab (param.get_string ()); //TODO Restore icon?
         }
 
         private void action_new_tab () requires (current_terminal != null) {
@@ -1006,7 +1008,7 @@ namespace Terminal {
                       notebook.tab_view.get_page_position (notebook.tab_menu_target) + 1 :
                       notebook.n_pages;
 
-            new_tab (term.get_shell_location (), null, true, pos);
+            new_tab (term.get_shell_location (), "", true, pos);
         }
 
         private void action_next_tab () {

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -725,9 +725,9 @@ namespace Terminal {
             }
         }
 
-        public void run_program (string _program_string, string? working_directory) {
+        public void run_program (string _program_string, string? working_directory) requires (_program_string.length > 0) {
             try {
-                string[]? program_with_args = null;
+                string[] program_with_args = {};
                 this.program_string = _program_string;
                 Shell.parse_argv (program_string, out program_with_args);
 
@@ -962,14 +962,13 @@ namespace Terminal {
             }
 
             contents_changed_timeout_id = Timeout.add (
+
                 CONTENTS_CHANGED_DELAY_MSEC,
                 () => {
                     if (contents_changed_continue) {
                         contents_changed_continue = false;
                         return Source.CONTINUE;
                     }
-
-                    contents_changed_timeout_id = 0;
 
                     var cwd = get_shell_location ();
                     if (cwd != current_working_directory) {
@@ -984,9 +983,16 @@ namespace Terminal {
                         fg_pid = pid;
                     }
 
+                    contents_changed_timeout_id = 0;
                     return Source.REMOVE;
                 }
             );
+        }
+
+        public void prepare_to_close () {
+            if (contents_changed_timeout_id > 0) {
+                Source.remove (contents_changed_timeout_id);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #873 

* Correctly determine whether killed process was  a child program or the shell
* Simplify by using non-nullable program string
* Remove timout before closing tab to prevent crash