### PR TITLE
Application: Gtk4 preparation

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,6 +1,6 @@
 /*
  * SPDX-License-Identifier: LGPL-3.0-or-later
- * SPDX-FileCopyrightText: 2011-25 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2011-2025 elementary, Inc. (https://elementary.io)
  */
 
 public class Terminal.Application : Gtk.Application {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -46,16 +46,8 @@ public class Terminal.Application : Gtk.Application {
                 }
             }
 
-            // This is a hack to avoid using Gdk-Xii dependency.  Using present_with_time ()
-            // with the current event time does not work either on X11 or Wayland perhaps
-            // because the triggering event did not occur on the Terminal window?
-            // Using set_keep_above () at least works on X11 but not on Wayland
-            //TODO It may well be possible to use present () on Gtk4 so this needs revisiting
-            window_to_present.set_keep_above (true);
-            window_to_present.present ();
-            window_to_present.grab_focus ();
             Idle.add (() => {
-                window_to_present.set_keep_above (false);
+                window_to_present.present ();
                 return Source.REMOVE;
             });
         });

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -46,10 +46,7 @@ public class Terminal.Application : Gtk.Application {
                 }
             }
 
-            Idle.add (() => {
-                window_to_present.present ();
-                return Source.REMOVE;
-            });
+            window_to_present.present ();
         });
 
         add_main_option ("version", 'v', 0, OptionArg.NONE, _("Show version"), null);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -202,12 +202,11 @@ public class Terminal.Application : Gtk.Application {
                     withdraw_notification_for_terminal (terminal, id, tab_change_handler, focus_in_handler);
                 });
 
-                focus_in_handler = terminal.main_window.focus_in_event.connect (() => {
-                    withdraw_notification_for_terminal (terminal, id, tab_change_handler, focus_in_handler);
-
-                    return Gdk.EVENT_PROPAGATE;
+                focus_in_handler = terminal.main_window.notify["is-active"].connect (() => {
+                    if (terminal.main_window.is_active) {
+                        withdraw_notification_for_terminal (terminal, id, tab_change_handler, focus_in_handler);
+                    }
                 });
-
             }
         });
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -1,6 +1,6 @@
 /*
- * Copyright 2011-2023 elementary, Inc. (https://elementary.io)
- * SPDX-License-Identifier: LGPL-3.0-only
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2011-25 elementary, Inc. (https://elementary.io)
  */
 
 public class Terminal.Application : Gtk.Application {

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -188,7 +188,7 @@ public class Terminal.Application : Gtk.Application {
                 terminal.tab.icon = process_icon;
             }
 
-            if (!(Gdk.WindowState.FOCUSED in terminal.main_window.get_window ().get_state ())) {
+            if (!(get_active_window ().is_active)) {
                 var notification = new Notification (process_string);
                 notification.set_body (process);
                 notification.set_icon (process_icon);


### PR DESCRIPTION
Some fairly substantive changes around `process-finished` notifications.

TODO (maybe).

Changes need to be made around restoring window size which entail changing the settings schema. These could be done before or during the port and are left for another PR.

@danirabbit When is the correct time to make settings schema changes?