### PR TITLE
Mainwindow: Gtk4 preparation

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -492,6 +492,7 @@ namespace Terminal {
             return false;
         }
 
+        //TODO Replace with separate window-width and window-height settings which are bound to the corresponding default properties
         private void restore_saved_state () {
             var rect = Gdk.Rectangle ();
             Terminal.Application.saved_state.get ("window-size", "(ii)", out rect.width, out rect.height);
@@ -611,6 +612,7 @@ namespace Terminal {
             return appinfo;
         }
 
+        //TODO Remove for Gtk4 and replace with bindings between settings and properties
         protected override bool configure_event (Gdk.EventConfigure event) {
             // triggered when the size, position or stacking of the window has changed
             // it is delayed 400ms to prevent spamming gsettings

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -303,7 +303,7 @@ namespace Terminal {
             search_button = new Gtk.ToggleButton () {
                 action_name = ACTION_PREFIX + ACTION_SEARCH,
                 image = new Gtk.Image.from_icon_name ("edit-find-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
-                valign = Gtk.Align.CENTER,
+                valign = CENTER,
                 tooltip_markup = Granite.markup_accel_tooltip ({"<Ctrl><Shift>f"}, _("Find…"))
             };
 
@@ -312,7 +312,7 @@ namespace Terminal {
                 image = new Gtk.Image.from_icon_name ("open-menu-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
                 popover = new SettingsPopover (),
                 tooltip_text = _("Settings"),
-                valign = Gtk.Align.CENTER
+                valign = CENTER
             };
 
             search_toolbar = new Terminal.Widgets.SearchToolbar (this);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -878,6 +878,7 @@ namespace Terminal {
             }
         }
 
+        //TODO Make TerminalWidget.confirm_kill_fg_process asynchronous and terminate all in callback
         public bool on_delete_event () {
             //Avoid saved terminals being overwritten when tabs destroyed.
             notebook.tab_view.page_detached.disconnect (on_tab_removed);

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -48,6 +48,11 @@ namespace Terminal.Utils {
 
         } while (path.contains ("//"));
 
+        // If just basename of file then assume in current shell location
+        if (!path.contains (Path.DIR_SEPARATOR_S)) {
+            path = string.join (Path.DIR_SEPARATOR_S, ".", path);
+        }
+
         var parts_sep = path.split (Path.DIR_SEPARATOR_S, 3);
         var index = 0;
         while (parts_sep[index] == null && index < parts_sep.length - 1) {


### PR DESCRIPTION
The substantive changes in this PR are around opening a uri or file path in the appropriate app. `Gtk.show_uri_on_window` does not exist in Gtk4 so an alternative approach is used that works both on Gtk3 and Gtk4.  Should probably move to Gtk.UriLauncher after porting but I could not get that to work last time I tried.