### PR TITLE
Don't sanitize URI on drop

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -835,7 +835,6 @@ namespace Terminal {
                 case DropTargets.URILIST:
                     var uris = selection_data.get_uris ();
                     string path;
-                    File file;
                     for (var i = 0; i < uris.length; i++) {
                         // Get unquoted path as some apps may drop uris that are escaped
                         // and quoted.
@@ -846,10 +845,10 @@ namespace Terminal {
                             warning ("Error unquoting %s. %s", uris[i], e.message);
                             unquoted_uri = uris[i];
                         }
-                        // Sanitize the path as we do not want the `file://` scheme included
-                        // and we assume dropped paths are absolute.
-                        file = File.new_for_uri (Utils.sanitize_path (unquoted_uri, "", false));
-                        path = file.get_path ();
+
+                        // Get path as we do not want the `file://` scheme included
+                        // and we assume dropped paths are absolute so no need for Utils.sanitize_path
+                        path = File.new_for_uri (unquoted_uri).get_path ();
                         if (path != null) {
                             uris[i] = Shell.quote (path) + " ";
                         } else {


### PR DESCRIPTION
Fixes https://github.com/elementary/terminal/issues/876
Closes https://github.com/elementary/terminal/pull/877

URIs **must** escape special characters and Utils.sanitize_path undoes this. Furthermore, there's no other reasons to use  Utils.sanitize_path here -- dropped paths must be absolute. So in conclusion if a file manager does everything correctly, we shouldn't need this. I tested this branch using Dolphin.