### PR TITLE
Explicitly focus tab on startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -717,6 +717,12 @@ namespace Terminal {
             if (focus_restored_tabs) {
                 var tab = notebook.tab_view.get_nth_page (focus.clamp (0, notebook.n_pages - 1));
                 notebook.selected_page = tab;
+                // On start up the "selected-page" notify signal is not always emitted/received
+                // for the first tab so focus the terminal explicitly
+                //TODO This may be a feature of the Hdy.TabView so review this on port to
+                // Gtk4.
+                var term = get_term_widget (notebook.tab_view.selected_page);
+                term.grab_focus ();
             }
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -720,10 +720,6 @@ namespace Terminal {
             if (focus_restored_tabs) {
                 var tab = notebook.tab_view.get_nth_page (focus.clamp (0, notebook.n_pages - 1));
                 notebook.selected_page = tab;
-                // On start up the "selected-page" notify signal is not always emitted/received
-                // for the first tab so focus the terminal explicitly
-                //TODO This may be a feature of the Hdy.TabView so review this on port to
-                // Gtk4.
             }
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -243,6 +243,9 @@ namespace Terminal {
                 open_tabs ();
             }
 
+            var term = get_term_widget (notebook.tab_view.selected_page);
+            term.grab_focus ();
+
             delete_event.connect (on_delete_event);
         }
 
@@ -721,8 +724,6 @@ namespace Terminal {
                 // for the first tab so focus the terminal explicitly
                 //TODO This may be a feature of the Hdy.TabView so review this on port to
                 // Gtk4.
-                var term = get_term_widget (notebook.tab_view.selected_page);
-                term.grab_focus ();
             }
         }
 


### PR DESCRIPTION
Fixes #899 

This issue seems to be cause by a "feature" of the Hdy.TabView whereby the `notify["selected-page"]` signal is not emitted when the first tab is programmatically selected on start up.  The required tab is therefore focused on start up.  (It was not thought worthwhile testing whether it is the first tab, but this could be done if desired).