### PR TITLE
Only embedded newlines should trigger safe paste warning

### DIFF
--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -136,7 +136,9 @@ namespace Terminal.Utils {
      */
     public bool is_safe_paste (string text, out string[]? msg_array) {
         string[] msgs = {};
-        if ("\n" in text || "&" in text || "|" in text || ";" in text ) {
+        var newline_index = text.index_of ("\n"); // First occurrence of new line
+        bool embedded_newline = newline_index >= 0 && newline_index < text.length - 1;
+        if (embedded_newline || "&" in text || "|" in text || ";" in text ) {
             msgs += _("The pasted text may contain multiple commands");
         }
 

--- a/src/tests/UnsafePasteTest.vala
+++ b/src/tests/UnsafePasteTest.vala
@@ -27,7 +27,8 @@ private void main (string[] args) {
         assert (!Terminal.Utils.is_safe_paste ("sudo apt autoremove", out msg_array));
 
         // Multi-line commands
-        assert (!Terminal.Utils.is_safe_paste ("\n", out msg_array));
+        assert (Terminal.Utils.is_safe_paste ("xx\n", out msg_array));
+        assert (!Terminal.Utils.is_safe_paste ("xx\nyy", out msg_array));
         assert (!Terminal.Utils.is_safe_paste ("&", out msg_array));
         assert (!Terminal.Utils.is_safe_paste ("|", out msg_array));
         assert (!Terminal.Utils.is_safe_paste (";", out msg_array));


### PR DESCRIPTION
Fixes #891 
