### PR TITLE
Metainfo: rename file, add screenshot env, no translate old releases

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -20,8 +20,8 @@ i18n.merge_file(
 )
 
 i18n.merge_file(
-    input: meson.project_name() + '.appdata.xml.in',
-    output: '@BASENAME@',
+    input: 'terminal.metainfo.xml.in',
+    output: meson.project_name() + '.metainfo.xml.in',
     po_dir: podir / 'extra',
     install: true,
     install_dir: datadir / 'metainfo'

--- a/data/terminal.metainfo.xml.in
+++ b/data/terminal.metainfo.xml.in
@@ -14,22 +14,22 @@
   </description>
 
   <screenshots>
-    <screenshot type="default">
+    <screenshot environment="pantheon" type="default">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot environment="pantheon">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot-light.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot environment="pantheon">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot-high-contrast.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot environment="pantheon">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot-find.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot environment="pantheon">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot-custom-style.png</image>
     </screenshot>
-    <screenshot>
+    <screenshot environment="pantheon">
       <image>https://raw.githubusercontent.com/elementary/terminal/7.1.1/data/screenshot-paste-protection.png</image>
     </screenshot>
   </screenshots>
@@ -40,11 +40,12 @@
     <binary>io.elementary.terminal</binary>
   </provides>
 
-  <url type="homepage">https://elementary.io/</url>
   <url type="bugtracker">https://github.com/elementary/terminal/issues</url>
   <url type="donation">https://elementary.io/get-involved#funding</url>
   <url type="help">https://github.com/elementary/terminal/discussions/categories/q-a</url>
+  <url type="homepage">https://elementary.io/</url>
   <url type="translate">https://l10n.elementary.io/projects/terminal/</url>
+  <url type="vcs-browser">https://github.com/elementary/terminal</url>
 
   <developer id="org.elementaryos">
     <name>elementary, Inc.</name>
@@ -78,6 +79,7 @@
         <issue url="https://github.com/elementary/terminal/issues/831">Process exit status icon remains forever</issue>
       </issues>
     </release>
+
     <release version="7.1.0" date="2025-08-05" urgency="medium">
       <description>
         <p>New features:</p>
@@ -132,7 +134,7 @@
     </release>
 
     <release version="6.3.0" date="2024-12-09" urgency="medium">
-      <description>
+      <description translate="no">
         <p>New features:</p>
         <ul>
           <li>Show zoom level in overlay when zooming</li>
@@ -163,7 +165,7 @@
     </release>
 
     <release version="6.2.0" date="2024-07-18" urgency="medium">
-      <description>
+      <description translate="no">
         <p>New features:</p>
         <ul>
           <li>Allow switching event alerts on and off in the app menu</li>
@@ -186,7 +188,7 @@
     </release>
 
     <release version="6.1.2" date="2023-04-03" urgency="medium">
-      <description>
+      <description translate="no">
         <p>Other updates:</p>
         <ul>
           <li>Add shortcuts "Ctrl + PageUp" and "Ctrl + PageDown" to switch between tabs</li>
@@ -203,7 +205,7 @@
     </release>
 
     <release version="6.1.1" date="2022-10-26" urgency="medium">
-      <description>
+      <description translate="no">
         <p>Other updates:</p>
         <ul>
           <li>Translation updates</li>
@@ -215,7 +217,7 @@
     </release>
 
     <release version="6.1.0" date="2022-08-11" urgency="medium">
-      <description>
+      <description translate="no">
         <p>New features:</p>
         <ul>
           <li>Option to follow system dark style preference</li>
@@ -234,7 +236,7 @@
     </release>
 
     <release version="6.0.2" date="2022-05-16" urgency="medium">
-      <description>
+      <description translate="no">
         <p>New features:</p>
         <ul>
           <li>Switch tabs with Alt + 1-9</li>

--- a/po/extra/POTFILES
+++ b/po/extra/POTFILES
@@ -1,2 +1,2 @@
-data/io.elementary.terminal.appdata.xml.in
+data/terminal.metainfo.xml.in
 data/io.elementary.terminal.desktop.in


### PR DESCRIPTION
* Rename as `metainfo` and use meson renaming
* add `environment` tag to screenshots
* add `vcs-browser` url
* Mark old release notes as no translate