### PR TITLE
MainWindow: set strict centering in header

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -326,11 +326,8 @@ namespace Terminal {
 
             title_stack = new Gtk.Stack () {
                 transition_type = Gtk.StackTransitionType.SLIDE_UP_DOWN,
-                hhomogeneous = false,
-                hexpand = false
+                hhomogeneous = false
             };
-
-            search_toolbar.width_request = 300;
             title_stack.add (title_label);
             title_stack.add (search_toolbar);
             // Must show children before visible_child can be set
@@ -339,6 +336,7 @@ namespace Terminal {
             title_stack.visible_child = title_label;
 
             header = new Hdy.HeaderBar () {
+                centering_policy = STRICT,
                 show_close_button = true,
                 has_subtitle = false
             };


### PR DESCRIPTION
Instead of hardcoding search width, use strict centering policy