### PR TITLE
Simplify make restorable

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -370,7 +370,7 @@ namespace Terminal {
                     }
 
                     if (Application.settings.get_boolean ("save-exited-tabs")) {
-                        make_restorable (term);
+                        notebook.make_restorable (term.current_working_directory);
                     }
 
                     disconnect_terminal_signals (term);
@@ -842,19 +842,6 @@ namespace Terminal {
 
             tab.child.show_all ();
             return tab;
-        }
-
-        private void make_restorable (TerminalWidget term) {
-            //FIXME Terminal child always exits when tab is closed (unlike Granite.DynamicNotebook)
-            if (Application.settings.get_boolean ("save-exited-tabs")) {
-                notebook.make_restorable (term.current_working_directory);
-            }
-
-            if (!term.child_has_exited) {
-                term.term_ps ();
-            }
-
-            return;
         }
 
         private void update_font () {


### PR DESCRIPTION
No need for a separate `make_restorable` function in `MainWindow` and it was duplicating code in the `close-page` handler.

Now replaced by a single line in the handler.