### PR TITLE
Fix search shortcuts

### DIFF
--- a/src/Widgets/SearchToolbar.vala
+++ b/src/Widgets/SearchToolbar.vala
@@ -4,11 +4,11 @@
  */
 
 public class Terminal.Widgets.SearchToolbar : Granite.Box {
+    public weak MainWindow window { private get; construct; }
+
     private Gtk.ToggleButton cycle_button;
     private uint last_search_term_length = 0;
-
-    public weak MainWindow window { get; construct; }
-    public Gtk.SearchEntry search_entry;
+    private Gtk.SearchEntry search_entry;
 
     public SearchToolbar (MainWindow window) {
         Object (window: window);


### PR DESCRIPTION
Changes:
1. Change key controller propagation phase to CAPTURE, TARGET is too late :(
2. Check if search bar is focused using "focus_widget.is_ancestor (search_toolbar)" instead of directly checking if searchbar is focused. Gtk.SearchBar is a widget that has Gtk.Text as a child, so this text widget is getting the focus, not the searchbar itself.
3. Correctly implement search action, it was missing change_state handler. Activate function now just toggles the state.
4. Don't rely on search_button's state to determine search action state.