### PR TITLE
Allow Ctrl+Backspace for deleting words

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -426,7 +426,7 @@ namespace Terminal {
                     break;
 
                 case Gdk.Key.BackSpace:
-                    if (control_pressed) {
+                    if (control_pressed && !has_foreground_process ()) {
                         feed_child ("\x1b\x7f".data);
                         return Gdk.EVENT_STOP;
                     }


### PR DESCRIPTION
Fixes https://github.com/elementary/terminal/issues/714

This probably interferes with some CLI applications. Does this need a toggle?