### PR TITLE
Ctrl + Click to open URLs

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -330,8 +330,10 @@ namespace Terminal {
         }
 
         private void primary_pressed (Gtk.GestureClick gesture, int n_press, double x, double y) {
+            var control_pressed = Gdk.ModifierType.CONTROL_MASK in gesture.get_current_event_state ();
+
             link_uri = null;
-            if (allow_hyperlink) {
+            if (allow_hyperlink && control_pressed) {
                 link_uri = get_link (x, y);
 
                 if (link_uri != null && !get_has_selection ()) {


### PR DESCRIPTION
Fixes https://github.com/elementary/terminal/issues/469
Fixes https://github.com/elementary/terminal/issues/653

All popular terminal emulators (Gnome Terminal, Gnome Console, Black Box, Konsole) open links on Ctrl + Click, so it's the default behaviour I guess