### PR TITLE
Offset appmenu popover to keep in window

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -300,7 +300,7 @@ namespace Terminal {
 
             menu_button.popover.show.connect (() => {
                 var p = menu_button.popover;
-                var is_ltr = (p.get_state_flags () & Gtk.StateFlags.DIR_LTR) > 0;
+                var is_ltr = Gtk.StateFlags.DIR_LTR in p.get_state_flags ();
                 Gtk.Requisition min, nat;
                 p.get_preferred_size (out min, out nat);
                 var offset = min.width / 2 - 12;


### PR DESCRIPTION
I noticed when preparing new screenshots that the AppMenu button popover no longer stays within the window. 
I believe this is due to differences between Gtk3 and Gtk4.  This PR maintains the previous appearance by offsetting the popover.

Please advise if there is a more elegant method.

BEFORE:
<img width="878" height="492" alt="Screenshot from 2025-11-25 15 11 05" src="https://github.com/user-attachments/assets/4731893b-9c56-473b-9560-b144795546a7" />
AFTER:
<img width="794" height="490" alt="Screenshot from 2025-11-25 15 09 57" src="https://github.com/user-attachments/assets/b7e8f755-a749-46d8-a551-8364e9bc655b" />
GTK3
<img width="986" height="692" alt="Screenshot from 2025-11-25 15 15 30" src="https://github.com/user-attachments/assets/9c47219f-857d-4e7f-b2ee-7df1c44fa0dd" />
