### PR TITLE
Provide fallback for title; set title in idle

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -288,12 +288,9 @@ namespace Terminal {
                     return;
                 }
 
-                title = term.window_title != "" ? term.window_title
-                                                : term.current_working_directory;
-
-
                 // Need to wait for default handler to run before focusing
                 Idle.add (() => {
+                    set_title ();
                     term.grab_focus ();
                     return Source.REMOVE;
                 });
@@ -463,8 +460,8 @@ namespace Terminal {
         private void connect_terminal_signals (TerminalWidget terminal_widget) {
             terminal_widget.child_exited.connect (on_terminal_child_exited);
             terminal_widget.cwd_changed.connect (on_terminal_cwd_changed);
-            terminal_widget.foreground_process_changed.connect (on_terminal_program_changed);
-            terminal_widget.window_title_changed.connect (on_terminal_window_title_changed);
+            terminal_widget.foreground_process_changed.connect (set_title);
+            terminal_widget.window_title_changed.connect (set_title);
         }
 
         private void on_terminal_child_exited (Vte.Terminal term, int status) {
@@ -491,8 +488,14 @@ namespace Terminal {
             }
         }
 
-        private void on_terminal_window_title_changed () {
-            title = current_terminal.window_title;
+        private void set_title () {
+            if (current_terminal.window_title != "") {
+                title = current_terminal.window_title;
+            } else if (current_terminal.current_working_directory != "") {
+                title = current_terminal.current_working_directory;
+            } else {
+                title = TerminalWidget.DEFAULT_LABEL; // Do we need a different fallback window title?
+            }
         }
 
         private bool close_immediately = false;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -761,8 +761,9 @@ namespace Terminal {
         }
 
         private void on_terminal_cwd_changed () {
-            check_for_tabs_with_same_name (); // Also sets window title
+            check_for_tabs_with_same_name ();
             save_opened_terminals (true, false);
+            set_title ();
         }
 
         private void on_terminal_program_changed (TerminalWidget src, string cmdline) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -766,11 +766,6 @@ namespace Terminal {
             set_title ();
         }
 
-        private void on_terminal_program_changed (TerminalWidget src, string cmdline) {
-            src.program_string = cmdline;
-            check_for_tabs_with_same_name (); // Also sets window title
-        }
-
         public void save_opened_terminals (bool save_tabs, bool save_zooms) {
             string[] zooms = {};
             string[] opened_tabs = {};

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -284,7 +284,7 @@ namespace Terminal {
 
                 // Need to wait for default handler to run before focusing
                 Idle.add (() => {
-                    set_title ();
+                    set_title_label ();
                     term.grab_focus ();
                     return Source.REMOVE;
                 });
@@ -449,8 +449,8 @@ namespace Terminal {
         private void connect_terminal_signals (TerminalWidget terminal_widget) {
             terminal_widget.child_exited.connect (on_terminal_child_exited);
             terminal_widget.cwd_changed.connect (on_terminal_cwd_changed);
-            terminal_widget.foreground_process_changed.connect (set_title);
-            terminal_widget.window_title_changed.connect (set_title);
+            terminal_widget.foreground_process_changed.connect (set_title_label);
+            terminal_widget.window_title_changed.connect (set_title_label);
         }
 
         private void on_terminal_child_exited (Vte.Terminal term, int status) {
@@ -477,7 +477,7 @@ namespace Terminal {
             }
         }
 
-        private void set_title () {
+        private void set_title_label () {
             if (current_terminal.window_title != "") {
                 title = current_terminal.window_title;
             } else if (current_terminal.current_working_directory != "") {
@@ -763,7 +763,7 @@ namespace Terminal {
         private void on_terminal_cwd_changed () {
             check_for_tabs_with_same_name ();
             save_opened_terminals (true, false);
-            set_title ();
+            set_title_label ();
         }
 
         public void save_opened_terminals (bool save_tabs, bool save_zooms) {


### PR DESCRIPTION
Fixes #992 
Fixes #1002 

Due to a suspected race condition in the "selected-page" handler, the window title is set later (in a pre-existing Idle).  Also a fallback for the title is now provided so it should never be blank.

It appears the `check_for_tabs_with_same_name` function used to update the window title but that is no longer the case.  The window title is now explicitly updated in the cwd change handler.