### PR TITLE
Fix excessive scroll speed in Wayland

### DIFF
--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -146,6 +146,8 @@ public class Terminal.TerminalView : Granite.Bin {
 
         var terminal_widget = new TerminalWidget () {
             scrollback_lines = Application.settings.get_int ("scrollback-lines"),
+            enable_fallback_scrolling = false,
+            scroll_unit_is_pixels = true,
             /* Make the terminal occupy the whole GUI */
             hexpand = true,
             vexpand = true

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -146,6 +146,7 @@ public class Terminal.TerminalView : Granite.Bin {
 
         var terminal_widget = new TerminalWidget () {
             scrollback_lines = Application.settings.get_int ("scrollback-lines"),
+            /* Ensure usable scroll speed on Wayland - see https://github.com/elementary/terminal/issues/993 */
             enable_fallback_scrolling = false,
             scroll_unit_is_pixels = true,
             /* Make the terminal occupy the whole GUI */


### PR DESCRIPTION
Fixes #993 

Thanks to @lobre 

These properties reduced scroll speed to a level consistent with other apps.