### PR TITLE
Do not show loading spinner for all foreground processes

### DIFF
--- a/data/terminal.metainfo.xml.in
+++ b/data/terminal.metainfo.xml.in
@@ -71,7 +71,6 @@
         </ul>
       </description>
       <issues>
-        <issue url="https://github.com/elementary/terminal/issues/317">Show symbol while terminal is working</issue>
         <issue url="https://github.com/elementary/terminal/issues/469">Ctrl + Click to open URLs</issue>
         <issue url="https://github.com/elementary/terminal/issues/510">Natural Copy/Paste. Ctrl+c clears the highlighted word. Ctrl+x doesn't.</issue>
         <issue url="https://github.com/elementary/terminal/issues/526">Changing font size when terminal has lots of output is slow.</issue>

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -168,7 +168,6 @@ public class Terminal.TerminalView : Granite.Bin {
 
         terminal_widget.notify["tab-state"].connect (() => {
             tab.icon = terminal_widget.tab_state.to_icon ();
-            tab.loading = terminal_widget.tab_state == WORKING;
         });
 
         // Set correct label now to avoid race when spawning shell

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -13,6 +13,7 @@ namespace Terminal {
 
             public GLib.Icon? to_icon () {
                 switch (this) {
+                    //TODO Should we have an icon for the presence of a foreground process?
                     case COMPLETED:
                         return new GLib.ThemedIcon ("process-completed-symbolic");
                     case ERROR:


### PR DESCRIPTION
Fixes #990
Fixes #991

Does not show an animated spinner for any foreground processes.

The "WORKING" tab state and related code is retained pending an alternative way of visualizing the presence of a foreground process and/or the progress of an ongoing process.