### PR TITLE
Fix secondary click foreground process

### DIFF
--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -298,7 +298,7 @@ namespace Terminal {
 
         private void secondary_pressed (Gtk.GestureSingle gesture, double x, double y) {
             if (has_foreground_process ()) {
-                gesture.set_state (CLAIMED);
+                gesture.set_state (DENIED);
                 return;
             }
 


### PR DESCRIPTION
I'm following up on the earlier issue where foreground applications were still receiving the terminal's right-click behavior when they should have handled secondary clicks themselves. That discussion led to PR #933, which disabled the terminal's secondary click actions while a foreground process is running.

That change fixed the context menu part, but it still used `CLAIMED` for the gesture sequence. In practice, that means the terminal keeps ownership of the secondary click, so apps like Kakoune may receive the first right click but not the following ones.

This change switches that path to `DENIED` instead. We still avoid showing the terminal's secondary click actions when a foreground process is active, but we let the right click events continue to the running application, which I believe is the behavior we want.