### PR TITLE
Show tab numbers with shortcut

### DIFF
--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -282,6 +282,12 @@ public class Terminal.TerminalView : Granite.Bin {
 
     private bool key_pressed (uint keyval, uint keycode, Gdk.ModifierType modifiers) {
         switch (keyval) {
+            //NOTE Keys @1 to @9 in combination with Alt_L do not natively change tab - they
+            // cause `bash` to enter "digit argument" mode. Whether this behaviour is overridden is determined
+            // by the "alt-changes-tab" setting.
+            // However keys KP_1 to KP_9 in combination with Alt_L is handled natively by Vte and always
+            // changes tab regardless of the setting.
+            // Holding down Alt_L causes tab numbers to appear in the tab labels regardless of the setting
             case Gdk.Key.@1: //alt+[1-8]
             case Gdk.Key.@2:
             case Gdk.Key.@3:
@@ -307,7 +313,7 @@ public class Terminal.TerminalView : Granite.Bin {
                 }
                 break;
 
-            case Gdk.Key.@0: //Show tab numbers
+            case Gdk.Key.@0:
             case Gdk.Key.KP_0:
                 if (ALT_MASK in modifiers && Application.settings.get_boolean ("alt-changes-tab")) {
                     show_tab_numbers ();

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -284,7 +284,7 @@ public class Terminal.TerminalView : Granite.Bin {
         switch (keyval) {
             //NOTE Keys @1 to @9 in combination with Alt_L do not natively change tab - they
             // cause `bash` to enter "digit argument" mode. Whether this behaviour is overridden is determined
-            // by the "alt-changes-tab" setting.
+            // by the "alt-changes-tab" setting (default true).
             // However keys KP_1 to KP_9 in combination with Alt_L is handled natively by Vte and always
             // changes tab regardless of the setting.
             // Holding down Alt_L causes tab numbers to appear in the tab labels regardless of the setting

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -103,7 +103,16 @@ public class Terminal.TerminalView : Granite.Bin {
             propagation_phase = CAPTURE
         };
         key_controller.key_pressed.connect (key_pressed);
+        key_controller.key_released.connect (key_released);
         add_controller (key_controller);
+
+        var focus_controller = new Gtk.EventControllerFocus () {
+            propagation_phase = CAPTURE
+        };
+        focus_controller.leave.connect (() => {
+            cancel_tab_numbers ();
+        });
+        add_controller (focus_controller);
 
         update_font ();
         gnome_interface_settings.changed["monospace-font-name"].connect (update_font);
@@ -267,6 +276,10 @@ public class Terminal.TerminalView : Granite.Bin {
         open_in_new_window_action.set_enabled (page != null && tab_view.n_pages > 1);
     }
 
+    private void key_released (uint keyval, uint keycode, Gdk.ModifierType modifiers) {
+        cancel_tab_numbers ();
+    }
+
     private bool key_pressed (uint keyval, uint keycode, Gdk.ModifierType modifiers) {
         switch (keyval) {
             case Gdk.Key.@1: //alt+[1-8]
@@ -288,14 +301,79 @@ public class Terminal.TerminalView : Granite.Bin {
                 break;
 
             case Gdk.Key.@9:
-                if (ALT_MASK in modifiers && Application.settings.get_boolean ("alt-changes-tab") && n_pages > 0) {
+                if (n_pages > 0 && ALT_MASK in modifiers && Application.settings.get_boolean ("alt-changes-tab")) {
                     selected_page = tab_view.get_nth_page (n_pages - 1);
                     return Gdk.EVENT_STOP;
+                }
+                break;
+
+            case Gdk.Key.@0: //Show tab numbers
+            case Gdk.Key.KP_0:
+                if (ALT_MASK in modifiers && Application.settings.get_boolean ("alt-changes-tab")) {
+                    show_tab_numbers ();
+                    return Gdk.EVENT_STOP;
+                }
+                break;
+
+            default:
+                if (keyval == Gdk.Key.Alt_L) {
+                    schedule_tab_numbers ();
                 }
                 break;
         }
 
         return Gdk.EVENT_PROPAGATE;
+    }
+
+    private uint tab_number_timeout = 0;
+    private bool tab_numbers_showing = false;
+    private void schedule_tab_numbers () {
+        if (tab_numbers_showing || tab_number_timeout > 0) {
+            return;
+        }
+
+        tab_number_timeout = Timeout.add (
+            Gtk.Settings.get_default ().gtk_long_press_time,
+            () => {
+                tab_number_timeout = 0;
+                show_tab_numbers ();
+                return Source.REMOVE;
+            }
+        );
+    }
+
+
+    private void show_tab_numbers () {
+        tab_numbers_showing = true;
+        //TODO Show number as badge? Need way of converting number to suitable icon
+        // that can be used as TabPage.indicator_icon.
+        // For now use text
+        for (int i = 0; i < this.n_pages; i++) {
+            var tab = this.tab_view.get_nth_page (i);
+            var badge = "(%d) ".printf (i + 1);
+            if (!tab.title.has_prefix (badge)) {
+                tab.title = badge + tab.title;
+            }
+        }
+    }
+
+    private void cancel_tab_numbers () {
+        if (tab_number_timeout > 0) {
+            Source.remove (tab_number_timeout);
+            tab_number_timeout = 0;
+        }
+
+        if (tab_numbers_showing) {
+            for (int i = 0; i < this.n_pages; i++) {
+                var tab = this.tab_view.get_nth_page (i);
+                var badge = "(%d) ".printf (i + 1);
+                if (tab.title.has_prefix (badge)) {
+                    tab.title = tab.title.slice (badge.length, tab.title.length);
+                }
+            }
+
+            tab_numbers_showing = false;
+        }
     }
 
     private void update_font () {


### PR DESCRIPTION
Fixes https://github.com/elementary/terminal/issues/655

We can't just show tab numbers immediatley when <Alt> is pressed as this key is also used for e.g. <Alt>BackSpace>. The solution adopted is to use a "long-press" on the <Alt> key. A previous solution was to use the unused <Alt>+0 combination to show the tab numbers immediately. This is retained for now but can be removed if considered superfluous.

The tab numbers are removed when a key is released, another key is pressed or focus lost.

It would be better to used an icon to show the numbers as that would be independent of the label and there is a suitable tabpage property, but there is no quick way to create an icon from a number (Gtk.NumerableIcon is discontinued in Gtk4) and we cannot use an overlay as TabPage is sealed.

So the tab number is prefixed to the tab label for now.

<img width="922" height="558" alt="image" src="https://github.com/user-attachments/assets/f19861f7-dfd1-487e-88d9-6b4672c70a2f" />
