### PR TITLE
Add RequestAttention DBus method for tabs needing input

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ Terminal implements process completion notifications. They are enabled for BASH 
     builtin . /usr/share/io.elementary.terminal/enable-zsh-completion-notifications || builtin true
 
 DISTRIBUTORS: depending on the policy of your distribution, either inform the user about this via the default mechanism for your distribution (for DIY distros like Arch), or add that line to `/etc/zshrc` automatically on installation (for preconfigured distros like Ubuntu).
+
+## Attention Requests
+
+Long-running interactive programs (for example AI agents) can ask the terminal to flag a tab when they need user input. The terminal marks the tab with an attention indicator and a `dialog-question-symbolic` icon, and posts a desktop notification if the window is not focused or the tab is not selected. The indicator clears automatically when the user focuses the tab.
+
+Each tab exports its identifier as `PANTHEON_TERMINAL_ID`. A program can request attention with a single DBus call:
+
+    dbus-send --type=method_call --session \
+        --dest=io.elementary.terminal /io/elementary/terminal \
+        io.elementary.terminal.RequestAttention \
+        string:"$PANTHEON_TERMINAL_ID" \
+        string:"Waiting for confirmation"
+
+The second string is shown as the notification body and may be empty.

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -191,12 +191,22 @@ public class Terminal.Application : Gtk.Application {
             ulong focus_in_handler = 0;
 
             tab_change_handler = window.notify["current-terminal"].connect ((obj, pspec) => {
-                withdraw_attention_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+                withdraw_notification_for_terminal (
+                    (MainWindow) obj, terminal,
+                    "attention-requested-%s".printf (id),
+                    { TerminalWidget.TabState.ATTENTION },
+                    tab_change_handler, focus_in_handler
+                );
             });
 
             focus_in_handler = window.notify["is-active"].connect ((obj, pspec) => {
                 if (((MainWindow) obj).is_active) {
-                    withdraw_attention_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+                    withdraw_notification_for_terminal (
+                        (MainWindow) obj, terminal,
+                        "attention-requested-%s".printf (id),
+                        { TerminalWidget.TabState.ATTENTION },
+                        tab_change_handler, focus_in_handler
+                    );
                 }
             });
         });
@@ -247,12 +257,22 @@ public class Terminal.Application : Gtk.Application {
                 ulong focus_in_handler = 0;
 
                 tab_change_handler = ((MainWindow) terminal.root).notify["current-terminal"].connect ((obj, pspec) => {
-                    withdraw_notification_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+                    withdraw_notification_for_terminal (
+                        (MainWindow) obj, terminal,
+                        "process-finished-%s".printf (id),
+                        { TerminalWidget.TabState.COMPLETED, TerminalWidget.TabState.ERROR },
+                        tab_change_handler, focus_in_handler
+                    );
                 });
 
                 focus_in_handler = ((MainWindow) terminal.root).notify["is-active"].connect ((obj, pspec) => {
                     if (((MainWindow) obj).is_active) {
-                        withdraw_notification_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+                        withdraw_notification_for_terminal (
+                            (MainWindow) obj, terminal,
+                            "process-finished-%s".printf (id),
+                            { TerminalWidget.TabState.COMPLETED, TerminalWidget.TabState.ERROR },
+                            tab_change_handler, focus_in_handler
+                        );
                     }
                 });
 
@@ -263,27 +283,26 @@ public class Terminal.Application : Gtk.Application {
         return true;
     }
 
-    private void withdraw_notification_for_terminal (MainWindow window, TerminalWidget terminal, string id, ulong tab_change_handler, ulong focus_in_handler) {
+    private void withdraw_notification_for_terminal (
+        MainWindow window,
+        TerminalWidget terminal,
+        string notification_id,
+        TerminalWidget.TabState[] clear_states,
+        ulong tab_change_handler,
+        ulong focus_in_handler
+    ) {
         if (window.current_terminal != terminal) {
             return;
         }
 
-        terminal.tab_state = NONE;
-        withdraw_notification ("process-finished-%s".printf (id));
-
-        window.disconnect (tab_change_handler);
-        window.disconnect (focus_in_handler);
-    }
-
-    private void withdraw_attention_for_terminal (MainWindow window, TerminalWidget terminal, string id, ulong tab_change_handler, ulong focus_in_handler) {
-        if (window.current_terminal != terminal) {
-            return;
+        foreach (var state in clear_states) {
+            if (terminal.tab_state == state) {
+                terminal.tab_state = NONE;
+                break;
+            }
         }
 
-        if (terminal.tab_state == ATTENTION) {
-            terminal.tab_state = NONE;
-        }
-        withdraw_notification ("attention-requested-%s".printf (id));
+        withdraw_notification (notification_id);
 
         window.disconnect (tab_change_handler);
         window.disconnect (focus_in_handler);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -156,7 +156,6 @@ public class Terminal.Application : Gtk.Application {
 
         dbus.attention_requested.connect ((id, message) => {
             TerminalWidget terminal = null;
-
             foreach (var window in (List<MainWindow>) get_windows ()) {
                 if (terminal != null) {
                     break;
@@ -174,7 +173,7 @@ public class Terminal.Application : Gtk.Application {
                 terminal.tab_state = ATTENTION;
             }
 
-            if (window.is_active && terminal == window.current_terminal) {
+            if (window.is_active) {
                 return;
             }
 
@@ -183,6 +182,7 @@ public class Terminal.Application : Gtk.Application {
             if (message.length > 0) {
                 notification.set_body (message);
             }
+
             notification.set_icon (TerminalWidget.TabState.ATTENTION.to_icon ());
             notification.set_default_action_and_target_value ("app.process-finished", new Variant.string (id));
             send_notification ("attention-requested-%s".printf (id), notification);

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -154,6 +154,53 @@ public class Terminal.Application : Gtk.Application {
         var dbus = new DBus ();
         dbus_id = connection.register_object (object_path, dbus);
 
+        dbus.attention_requested.connect ((id, message) => {
+            TerminalWidget terminal = null;
+
+            foreach (var window in (List<MainWindow>) get_windows ()) {
+                if (terminal != null) {
+                    break;
+                }
+
+                terminal = window.get_terminal (id);
+            }
+
+            if (terminal == null) {
+                return;
+            }
+
+            unowned var window = (MainWindow) terminal.root;
+            if (terminal != window.current_terminal || !window.is_active) {
+                terminal.tab_state = ATTENTION;
+            }
+
+            if (window.is_active && terminal == window.current_terminal) {
+                return;
+            }
+
+            var notification_title = _("Terminal needs your attention");
+            var notification = new Notification (notification_title);
+            if (message.length > 0) {
+                notification.set_body (message);
+            }
+            notification.set_icon (TerminalWidget.TabState.ATTENTION.to_icon ());
+            notification.set_default_action_and_target_value ("app.process-finished", new Variant.string (id));
+            send_notification ("attention-requested-%s".printf (id), notification);
+
+            ulong tab_change_handler = 0;
+            ulong focus_in_handler = 0;
+
+            tab_change_handler = window.notify["current-terminal"].connect ((obj, pspec) => {
+                withdraw_attention_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+            });
+
+            focus_in_handler = window.notify["is-active"].connect ((obj, pspec) => {
+                if (((MainWindow) obj).is_active) {
+                    withdraw_attention_for_terminal ((MainWindow) obj, terminal, id, tab_change_handler, focus_in_handler);
+                }
+            });
+        });
+
         dbus.finished_process.connect ((id, process, exit_status) => {
             TerminalWidget terminal = null;
 
@@ -223,6 +270,20 @@ public class Terminal.Application : Gtk.Application {
 
         terminal.tab_state = NONE;
         withdraw_notification ("process-finished-%s".printf (id));
+
+        window.disconnect (tab_change_handler);
+        window.disconnect (focus_in_handler);
+    }
+
+    private void withdraw_attention_for_terminal (MainWindow window, TerminalWidget terminal, string id, ulong tab_change_handler, ulong focus_in_handler) {
+        if (window.current_terminal != terminal) {
+            return;
+        }
+
+        if (terminal.tab_state == ATTENTION) {
+            terminal.tab_state = NONE;
+        }
+        withdraw_notification ("attention-requested-%s".printf (id));
 
         window.disconnect (tab_change_handler);
         window.disconnect (focus_in_handler);

--- a/src/DBus.vala
+++ b/src/DBus.vala
@@ -23,11 +23,18 @@ namespace Terminal {
         [DBus (visible = false)]
         public signal void finished_process (string terminal_id, string process, int exit_status);
 
+        [DBus (visible = false)]
+        public signal void attention_requested (string terminal_id, string message);
+
         public DBus () {
         }
 
         public void process_finished (string terminal_id, string process, int exit_status) throws GLib.Error {
             finished_process (terminal_id, process, exit_status);
+        }
+
+        public void request_attention (string terminal_id, string message) throws GLib.Error {
+            attention_requested (terminal_id, message);
         }
     }
 }

--- a/src/Widgets/TerminalView.vala
+++ b/src/Widgets/TerminalView.vala
@@ -180,6 +180,7 @@ public class Terminal.TerminalView : Granite.Bin {
 
         terminal_widget.notify["tab-state"].connect (() => {
             tab.icon = terminal_widget.tab_state.to_icon ();
+            tab.needs_attention = terminal_widget.tab_state == ATTENTION;
         });
 
         // Set correct label now to avoid race when spawning shell

--- a/src/Widgets/TerminalWidget.vala
+++ b/src/Widgets/TerminalWidget.vala
@@ -9,7 +9,8 @@ namespace Terminal {
             NONE,
             WORKING,
             COMPLETED,
-            ERROR;
+            ERROR,
+            ATTENTION;
 
             public GLib.Icon? to_icon () {
                 switch (this) {
@@ -18,6 +19,8 @@ namespace Terminal {
                         return new GLib.ThemedIcon ("process-completed-symbolic");
                     case ERROR:
                         return new GLib.ThemedIcon ("process-error-symbolic");
+                    case ATTENTION:
+                        return new GLib.ThemedIcon ("dialog-question-symbolic");
                     default:
                         return null;
                 }


### PR DESCRIPTION
## Summary

- Adds a `TabState.ATTENTION` and a new DBus method `io.elementary.terminal.RequestAttention(terminal_id, message)` that lets a long-running program in a tab (notably AI agents) flag the tab when it needs user input.
- Reuses the existing process-completion plumbing: an icon (`dialog-question-symbolic`) is set on the tab, `Adw.TabPage.needs_attention` is toggled for the libadwaita accent-dot indicator, and a freedesktop notification is sent when the window/tab is not focused. State and notification clear automatically when the user focuses the tab.
- Documented in README under a new "Attention Requests" section.

## Why

When you have several long-running agent sessions in separate tabs, it's easy to miss when one of them is waiting for confirmation. This gives them a one-line, no-config way to ping you.

## Screencast
https://github.com/user-attachments/assets/347c360c-503e-4573-8e07-91dd6e620dca

## Test plan

- [ ] Build with `meson setup build && ninja -C build`
- [ ] Run `./build/src/io.elementary.terminal --gapplication-app-id=io.elementary.terminal.dev --new-window` and open two tabs
- [ ] In tab 1: `dbus-send --type=method_call --session --dest=io.elementary.terminal.dev /io/elementary/terminal/dev io.elementary.terminal.RequestAttention string:"$PANTHEON_TERMINAL_ID" string:"hello from agent"` — switch to tab 2 first; verify tab 1 shows the accent dot + question icon and a desktop notification appears
- [ ] Click tab 1: indicator clears, notification is withdrawn
- [ ] Repeat with the window unfocused (focus another app) — verify the desktop notification still appears